### PR TITLE
chore: add Docker, Compose, and K8s infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # AssetTrack
 Asset tracking system with role-based access control.
+
+## Local Development
+
+Run `docker-compose up -d`
+The PostgreSQL database runs on localhost:5432.
+pgAdmin is available at http://localhost:8081 (Login: admin@assettrack.com / admin).

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,18 @@
+FROM eclipse-temurin:21-jdk AS build
+
+RUN apt-get update && apt-get install -y maven
+
+WORKDIR /assettrack-backend
+
+COPY pom.xml .
+COPY src ./src
+
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:21-jdk
+
+WORKDIR /assettrack-backend
+COPY --from=build /assettrack-backend/target/*.jar app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    container_name: assettrack_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: assettrack
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      PGDATA: /var/lib/postgresql/data/pgdata
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - assettrack_network
+
+  # Optional: pgAdmin for database management
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: assettrack_pgadmin
+    restart: unless-stopped
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@assettrack.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "8081:80"
+    depends_on:
+      - postgres
+    networks:
+      - assettrack_network
+
+volumes:
+  postgres_data:
+
+networks:
+  assettrack_network:
+    driver: bridge

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -1,0 +1,68 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: assettrack-backend
+  labels:
+    app: assettrack-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: assettrack-backend
+  template:
+    metadata:
+      labels:
+        app: assettrack-backend
+    spec:
+      containers:
+      - name: assettrack-backend
+        image: DOCKER_IMAGE
+        resources:
+          requests:
+            memory: 200M
+            cpu: 100m
+          limits:
+            memory: 500M
+            cpu: 200m
+        ports:
+          - containerPort: 8080
+        envFrom:
+            - configMapRef:
+                  name: shared-environment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: assettrack-backend
+  name: assettrack-backend
+spec:
+  ports:
+    - name: "8080-8080"
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: assettrack-backend
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: assettrack-backend
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: assettrack-backend
+                port:
+                  number: 8080


### PR DESCRIPTION
This PR adds the Dockerfile, docker-compose.yml, and Kubernetes manifest adapted from the old roombooking project, and updates the README with local development instructions.