### PR TITLE
feat: implement DashboardService aggregation and quick-spare endpoints

### DIFF
--- a/backend/src/main/java/com/assettrack/controller/asset/AssetActionController.java
+++ b/backend/src/main/java/com/assettrack/controller/asset/AssetActionController.java
@@ -1,0 +1,22 @@
+package com.assettrack.controller.asset;
+
+import com.assettrack.domain.asset.Asset;
+import com.assettrack.service.dashboard.DashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/assets")
+@RequiredArgsConstructor
+public class AssetActionController {
+
+    private final DashboardService dashboardService;
+
+    @GetMapping("/quick-spare")
+    public ResponseEntity<Asset> getQuickSpareLaptop() {
+        return ResponseEntity.ok(dashboardService.getQuickSpareLaptop());
+    }
+}

--- a/backend/src/main/java/com/assettrack/controller/asset/AssetActionController.java
+++ b/backend/src/main/java/com/assettrack/controller/asset/AssetActionController.java
@@ -1,6 +1,6 @@
 package com.assettrack.controller.asset;
 
-import com.assettrack.domain.asset.Asset;
+import com.assettrack.dto.dashboard.QuickSpareAssetDto;
 import com.assettrack.service.dashboard.DashboardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +16,7 @@ public class AssetActionController {
     private final DashboardService dashboardService;
 
     @GetMapping("/quick-spare")
-    public ResponseEntity<Asset> getQuickSpareLaptop() {
+    public ResponseEntity<QuickSpareAssetDto> getQuickSpareLaptop() {
         return ResponseEntity.ok(dashboardService.getQuickSpareLaptop());
     }
 }

--- a/backend/src/main/java/com/assettrack/controller/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/assettrack/controller/dashboard/DashboardController.java
@@ -1,0 +1,22 @@
+package com.assettrack.controller.dashboard;
+
+import com.assettrack.dto.dashboard.DashboardSummaryDto;
+import com.assettrack.service.dashboard.DashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/dashboard")
+@RequiredArgsConstructor
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    @GetMapping("/summary")
+    public ResponseEntity<DashboardSummaryDto> getSummary() {
+        return ResponseEntity.ok(dashboardService.getSummary());
+    }
+}

--- a/backend/src/main/java/com/assettrack/domain/asset/Asset.java
+++ b/backend/src/main/java/com/assettrack/domain/asset/Asset.java
@@ -1,0 +1,38 @@
+package com.assettrack.domain.asset;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Asset {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AssetType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AssetStatus status;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/backend/src/main/java/com/assettrack/domain/asset/AssetStatus.java
+++ b/backend/src/main/java/com/assettrack/domain/asset/AssetStatus.java
@@ -1,5 +1,5 @@
 package com.assettrack.domain.asset;
 
 public enum AssetStatus {
-    AVAILABLE, ALLOCATED, EXPIRED, MAINTENANCE
+    AVAILABLE, ALLOCATED, EXPIRED
 }

--- a/backend/src/main/java/com/assettrack/domain/asset/AssetStatus.java
+++ b/backend/src/main/java/com/assettrack/domain/asset/AssetStatus.java
@@ -1,0 +1,5 @@
+package com.assettrack.domain.asset;
+
+public enum AssetStatus {
+    AVAILABLE, ALLOCATED, EXPIRED, MAINTENANCE
+}

--- a/backend/src/main/java/com/assettrack/domain/asset/AssetType.java
+++ b/backend/src/main/java/com/assettrack/domain/asset/AssetType.java
@@ -1,5 +1,5 @@
 package com.assettrack.domain.asset;
 
 public enum AssetType {
-    LAPTOP, MONITOR, PHONE, OTHER
+    LAPTOP, SCREEN, ACCESSORY
 }

--- a/backend/src/main/java/com/assettrack/domain/asset/AssetType.java
+++ b/backend/src/main/java/com/assettrack/domain/asset/AssetType.java
@@ -1,0 +1,5 @@
+package com.assettrack.domain.asset;
+
+public enum AssetType {
+    LAPTOP, MONITOR, PHONE, OTHER
+}

--- a/backend/src/main/java/com/assettrack/dto/dashboard/DashboardSummaryDto.java
+++ b/backend/src/main/java/com/assettrack/dto/dashboard/DashboardSummaryDto.java
@@ -4,13 +4,21 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Map;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class DashboardSummaryDto {
     private long totalAssets;
-    private Map<String, Long> statusDistribution;
-    private Map<String, Long> typeDistribution;
+    private ChartData statusDistribution;
+    private ChartData typeDistribution;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChartData {
+        private List<String> labels;
+        private List<Long> data;
+    }
 }

--- a/backend/src/main/java/com/assettrack/dto/dashboard/DashboardSummaryDto.java
+++ b/backend/src/main/java/com/assettrack/dto/dashboard/DashboardSummaryDto.java
@@ -1,0 +1,16 @@
+package com.assettrack.dto.dashboard;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DashboardSummaryDto {
+    private long totalAssets;
+    private Map<String, Long> statusDistribution;
+    private Map<String, Long> typeDistribution;
+}

--- a/backend/src/main/java/com/assettrack/dto/dashboard/QuickSpareAssetDto.java
+++ b/backend/src/main/java/com/assettrack/dto/dashboard/QuickSpareAssetDto.java
@@ -1,0 +1,14 @@
+package com.assettrack.dto.dashboard;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuickSpareAssetDto {
+    private Long id;
+    private String type;
+    private String status;
+}

--- a/backend/src/main/java/com/assettrack/repository/asset/AssetRepository.java
+++ b/backend/src/main/java/com/assettrack/repository/asset/AssetRepository.java
@@ -1,0 +1,33 @@
+package com.assettrack.repository.asset;
+
+import com.assettrack.domain.asset.Asset;
+import com.assettrack.domain.asset.AssetStatus;
+import com.assettrack.domain.asset.AssetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AssetRepository extends JpaRepository<Asset, Long> {
+
+    @Query("SELECT a.status as status, COUNT(a) as count FROM Asset a GROUP BY a.status")
+    List<StatusCount> countByStatus();
+
+    @Query("SELECT a.type as type, COUNT(a) as count FROM Asset a GROUP BY a.type")
+    List<TypeCount> countByType();
+
+    Optional<Asset> findFirstByTypeAndStatusOrderByCreatedAtAsc(AssetType type, AssetStatus status);
+
+    interface StatusCount {
+        AssetStatus getStatus();
+        Long getCount();
+    }
+
+    interface TypeCount {
+        AssetType getType();
+        Long getCount();
+    }
+}

--- a/backend/src/main/java/com/assettrack/service/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/assettrack/service/dashboard/DashboardService.java
@@ -1,0 +1,43 @@
+package com.assettrack.service.dashboard;
+
+import com.assettrack.domain.asset.Asset;
+import com.assettrack.domain.asset.AssetStatus;
+import com.assettrack.domain.asset.AssetType;
+import com.assettrack.dto.dashboard.DashboardSummaryDto;
+import com.assettrack.exception.ResourceNotFoundException;
+import com.assettrack.repository.asset.AssetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardService {
+
+    private final AssetRepository assetRepository;
+
+    public DashboardSummaryDto getSummary() {
+        long totalAssets = assetRepository.count();
+
+        Map<String, Long> statusDistribution = assetRepository.countByStatus().stream()
+                .collect(Collectors.toMap(
+                        sc -> sc.getStatus().name(),
+                        AssetRepository.StatusCount::getCount
+                ));
+
+        Map<String, Long> typeDistribution = assetRepository.countByType().stream()
+                .collect(Collectors.toMap(
+                        tc -> tc.getType().name(),
+                        AssetRepository.TypeCount::getCount
+                ));
+
+        return new DashboardSummaryDto(totalAssets, statusDistribution, typeDistribution);
+    }
+
+    public Asset getQuickSpareLaptop() {
+        return assetRepository.findFirstByTypeAndStatusOrderByCreatedAtAsc(AssetType.LAPTOP, AssetStatus.AVAILABLE)
+                .orElseThrow(() -> new ResourceNotFoundException("No available spare laptop found."));
+    }
+}

--- a/backend/src/main/java/com/assettrack/service/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/assettrack/service/dashboard/DashboardService.java
@@ -1,14 +1,16 @@
 package com.assettrack.service.dashboard;
 
-import com.assettrack.domain.asset.Asset;
 import com.assettrack.domain.asset.AssetStatus;
 import com.assettrack.domain.asset.AssetType;
 import com.assettrack.dto.dashboard.DashboardSummaryDto;
+import com.assettrack.dto.dashboard.QuickSpareAssetDto;
 import com.assettrack.exception.ResourceNotFoundException;
 import com.assettrack.repository.asset.AssetRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -21,23 +23,36 @@ public class DashboardService {
     public DashboardSummaryDto getSummary() {
         long totalAssets = assetRepository.count();
 
-        Map<String, Long> statusDistribution = assetRepository.countByStatus().stream()
-                .collect(Collectors.toMap(
-                        sc -> sc.getStatus().name(),
-                        AssetRepository.StatusCount::getCount
-                ));
+        Map<AssetStatus, Long> statusCounts = assetRepository.countByStatus().stream()
+                .collect(Collectors.toMap(AssetRepository.StatusCount::getStatus, AssetRepository.StatusCount::getCount));
 
-        Map<String, Long> typeDistribution = assetRepository.countByType().stream()
-                .collect(Collectors.toMap(
-                        tc -> tc.getType().name(),
-                        AssetRepository.TypeCount::getCount
-                ));
+        List<String> statusLabels = Arrays.stream(AssetStatus.values())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+        List<Long> statusData = Arrays.stream(AssetStatus.values())
+                .map(s -> statusCounts.getOrDefault(s, 0L))
+                .collect(Collectors.toList());
 
-        return new DashboardSummaryDto(totalAssets, statusDistribution, typeDistribution);
+        Map<AssetType, Long> typeCounts = assetRepository.countByType().stream()
+                .collect(Collectors.toMap(AssetRepository.TypeCount::getType, AssetRepository.TypeCount::getCount));
+
+        List<String> typeLabels = Arrays.stream(AssetType.values())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+        List<Long> typeData = Arrays.stream(AssetType.values())
+                .map(t -> typeCounts.getOrDefault(t, 0L))
+                .collect(Collectors.toList());
+
+        return new DashboardSummaryDto(
+                totalAssets,
+                new DashboardSummaryDto.ChartData(statusLabels, statusData),
+                new DashboardSummaryDto.ChartData(typeLabels, typeData)
+        );
     }
 
-    public Asset getQuickSpareLaptop() {
+    public QuickSpareAssetDto getQuickSpareLaptop() {
         return assetRepository.findFirstByTypeAndStatusOrderByCreatedAtAsc(AssetType.LAPTOP, AssetStatus.AVAILABLE)
+                .map(a -> new QuickSpareAssetDto(a.getId(), a.getType().name(), a.getStatus().name()))
                 .orElseThrow(() -> new ResourceNotFoundException("No available spare laptop found."));
     }
 }

--- a/backend/src/test/java/com/assettrack/security/SecurityFilterChainTest.java
+++ b/backend/src/test/java/com/assettrack/security/SecurityFilterChainTest.java
@@ -2,6 +2,7 @@ package com.assettrack.security;
 
 import com.assettrack.repository.user.UserRepository;
 import com.assettrack.service.auth.AuthService;
+import com.assettrack.service.dashboard.DashboardService;
 import com.assettrack.service.user.UserService;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
@@ -45,6 +46,15 @@ public class SecurityFilterChainTest {
 
     @MockBean
     private UserService userService;
+
+    @MockBean
+    private DashboardService dashboardService;
+
+    @MockBean
+    private com.assettrack.service.notification.AlertService alertService;
+
+    @MockBean
+    private com.assettrack.service.notification.EmailNotificationService emailNotificationService;
 
     @MockBean
     private UserRepository userRepository;

--- a/backend/src/test/java/com/assettrack/service/dashboard/DashboardIntegrationTest.java
+++ b/backend/src/test/java/com/assettrack/service/dashboard/DashboardIntegrationTest.java
@@ -1,0 +1,72 @@
+package com.assettrack.service.dashboard;
+
+import com.assettrack.domain.asset.Asset;
+import com.assettrack.domain.asset.AssetStatus;
+import com.assettrack.domain.asset.AssetType;
+import com.assettrack.dto.dashboard.DashboardSummaryDto;
+import com.assettrack.exception.ResourceNotFoundException;
+import com.assettrack.repository.asset.AssetRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(properties = {
+    "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1",
+    "spring.datasource.driverClassName=org.h2.Driver",
+    "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect"
+})
+@ActiveProfiles("test")
+public class DashboardIntegrationTest {
+
+    @Autowired
+    private DashboardService dashboardService;
+
+    @Autowired
+    private AssetRepository assetRepository;
+
+    @BeforeEach
+    void setUp() {
+        assetRepository.deleteAll();
+    }
+
+    @Test
+    void testDashboardSummaryAggregation() {
+        assetRepository.save(Asset.builder().type(AssetType.LAPTOP).status(AssetStatus.AVAILABLE).build());
+        assetRepository.save(Asset.builder().type(AssetType.LAPTOP).status(AssetStatus.ALLOCATED).build());
+        assetRepository.save(Asset.builder().type(AssetType.MONITOR).status(AssetStatus.AVAILABLE).build());
+
+        DashboardSummaryDto summary = dashboardService.getSummary();
+
+        assertThat(summary.getTotalAssets()).isEqualTo(3L);
+        assertThat(summary.getStatusDistribution()).containsEntry("AVAILABLE", 2L).containsEntry("ALLOCATED", 1L);
+        assertThat(summary.getTypeDistribution()).containsEntry("LAPTOP", 2L).containsEntry("MONITOR", 1L);
+    }
+
+    @Test
+    void testGetQuickSpareLaptop_Found() {
+        Asset laptop1 = Asset.builder().type(AssetType.LAPTOP).status(AssetStatus.AVAILABLE).build();
+        Asset laptop2 = Asset.builder().type(AssetType.LAPTOP).status(AssetStatus.AVAILABLE).build();
+        
+        assetRepository.save(laptop1);
+        assetRepository.save(laptop2);
+
+        Asset found = dashboardService.getQuickSpareLaptop();
+        assertThat(found).isNotNull();
+        assertThat(found.getType()).isEqualTo(AssetType.LAPTOP);
+        assertThat(found.getStatus()).isEqualTo(AssetStatus.AVAILABLE);
+    }
+
+    @Test
+    void testGetQuickSpareLaptop_NotFound() {
+        assetRepository.save(Asset.builder().type(AssetType.LAPTOP).status(AssetStatus.ALLOCATED).build());
+        assetRepository.save(Asset.builder().type(AssetType.MONITOR).status(AssetStatus.AVAILABLE).build());
+
+        assertThatThrownBy(() -> dashboardService.getQuickSpareLaptop())
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/assettrack/service/dashboard/DashboardIntegrationTest.java
+++ b/backend/src/test/java/com/assettrack/service/dashboard/DashboardIntegrationTest.java
@@ -4,13 +4,30 @@ import com.assettrack.domain.asset.Asset;
 import com.assettrack.domain.asset.AssetStatus;
 import com.assettrack.domain.asset.AssetType;
 import com.assettrack.dto.dashboard.DashboardSummaryDto;
+import com.assettrack.dto.dashboard.QuickSpareAssetDto;
 import com.assettrack.exception.ResourceNotFoundException;
 import com.assettrack.repository.asset.AssetRepository;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -18,7 +35,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @SpringBootTest(properties = {
     "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1",
     "spring.datasource.driverClassName=org.h2.Driver",
-    "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect"
+    "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+    "spring.main.allow-bean-definition-overriding=true"
 })
 @ActiveProfiles("test")
 public class DashboardIntegrationTest {
@@ -29,6 +47,43 @@ public class DashboardIntegrationTest {
     @Autowired
     private AssetRepository assetRepository;
 
+    @TestConfiguration
+    static class TestRsaKeyConfig {
+
+        private static final KeyPair KEY_PAIR;
+
+        static {
+            try {
+                KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+                generator.initialize(2048);
+                KEY_PAIR = generator.generateKeyPair();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to generate test RSA key pair", e);
+            }
+        }
+
+        @Bean
+        public RSAPublicKey publicKey() {
+            return (RSAPublicKey) KEY_PAIR.getPublic();
+        }
+
+        @Bean
+        public RSAPrivateKey privateKey() {
+            return (RSAPrivateKey) KEY_PAIR.getPrivate();
+        }
+
+        @Bean
+        public JwtEncoder jwtEncoder(RSAPublicKey publicKey, RSAPrivateKey privateKey) {
+            JWK jwk = new RSAKey.Builder(publicKey).privateKey(privateKey).build();
+            return new NimbusJwtEncoder(new ImmutableJWKSet<>(new JWKSet(jwk)));
+        }
+
+        @Bean
+        public JwtDecoder jwtDecoder(RSAPublicKey publicKey) {
+            return NimbusJwtDecoder.withPublicKey(publicKey).build();
+        }
+    }
+
     @BeforeEach
     void setUp() {
         assetRepository.deleteAll();
@@ -38,13 +93,25 @@ public class DashboardIntegrationTest {
     void testDashboardSummaryAggregation() {
         assetRepository.save(Asset.builder().type(AssetType.LAPTOP).status(AssetStatus.AVAILABLE).build());
         assetRepository.save(Asset.builder().type(AssetType.LAPTOP).status(AssetStatus.ALLOCATED).build());
-        assetRepository.save(Asset.builder().type(AssetType.MONITOR).status(AssetStatus.AVAILABLE).build());
+        assetRepository.save(Asset.builder().type(AssetType.SCREEN).status(AssetStatus.AVAILABLE).build());
 
         DashboardSummaryDto summary = dashboardService.getSummary();
 
         assertThat(summary.getTotalAssets()).isEqualTo(3L);
-        assertThat(summary.getStatusDistribution()).containsEntry("AVAILABLE", 2L).containsEntry("ALLOCATED", 1L);
-        assertThat(summary.getTypeDistribution()).containsEntry("LAPTOP", 2L).containsEntry("MONITOR", 1L);
+
+        List<String> statusLabels = summary.getStatusDistribution().getLabels();
+        List<Long> statusData = summary.getStatusDistribution().getData();
+        assertThat(statusLabels).containsExactly("AVAILABLE", "ALLOCATED", "EXPIRED");
+        assertThat(statusData.get(statusLabels.indexOf("AVAILABLE"))).isEqualTo(2L);
+        assertThat(statusData.get(statusLabels.indexOf("ALLOCATED"))).isEqualTo(1L);
+        assertThat(statusData.get(statusLabels.indexOf("EXPIRED"))).isEqualTo(0L);
+
+        List<String> typeLabels = summary.getTypeDistribution().getLabels();
+        List<Long> typeData = summary.getTypeDistribution().getData();
+        assertThat(typeLabels).containsExactly("LAPTOP", "SCREEN", "ACCESSORY");
+        assertThat(typeData.get(typeLabels.indexOf("LAPTOP"))).isEqualTo(2L);
+        assertThat(typeData.get(typeLabels.indexOf("SCREEN"))).isEqualTo(1L);
+        assertThat(typeData.get(typeLabels.indexOf("ACCESSORY"))).isEqualTo(0L);
     }
 
     @Test
@@ -55,16 +122,16 @@ public class DashboardIntegrationTest {
         assetRepository.save(laptop1);
         assetRepository.save(laptop2);
 
-        Asset found = dashboardService.getQuickSpareLaptop();
+        QuickSpareAssetDto found = dashboardService.getQuickSpareLaptop();
         assertThat(found).isNotNull();
-        assertThat(found.getType()).isEqualTo(AssetType.LAPTOP);
-        assertThat(found.getStatus()).isEqualTo(AssetStatus.AVAILABLE);
+        assertThat(found.getType()).isEqualTo("LAPTOP");
+        assertThat(found.getStatus()).isEqualTo("AVAILABLE");
     }
 
     @Test
     void testGetQuickSpareLaptop_NotFound() {
         assetRepository.save(Asset.builder().type(AssetType.LAPTOP).status(AssetStatus.ALLOCATED).build());
-        assetRepository.save(Asset.builder().type(AssetType.MONITOR).status(AssetStatus.AVAILABLE).build());
+        assetRepository.save(Asset.builder().type(AssetType.SCREEN).status(AssetStatus.AVAILABLE).build());
 
         assertThatThrownBy(() -> dashboardService.getQuickSpareLaptop())
                 .isInstanceOf(ResourceNotFoundException.class);

--- a/backend/src/test/java/com/assettrack/service/dashboard/DashboardServiceTest.java
+++ b/backend/src/test/java/com/assettrack/service/dashboard/DashboardServiceTest.java
@@ -1,5 +1,6 @@
 package com.assettrack.service.dashboard;
 
+import com.assettrack.domain.asset.Asset;
 import com.assettrack.domain.asset.AssetStatus;
 import com.assettrack.domain.asset.AssetType;
 import com.assettrack.dto.dashboard.DashboardSummaryDto;
@@ -18,7 +19,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
-import com.assettrack.domain.asset.Asset;
 
 @ExtendWith(MockitoExtension.class)
 class DashboardServiceTest {

--- a/backend/src/test/java/com/assettrack/service/dashboard/DashboardServiceTest.java
+++ b/backend/src/test/java/com/assettrack/service/dashboard/DashboardServiceTest.java
@@ -1,9 +1,9 @@
 package com.assettrack.service.dashboard;
 
-import com.assettrack.domain.asset.Asset;
 import com.assettrack.domain.asset.AssetStatus;
 import com.assettrack.domain.asset.AssetType;
 import com.assettrack.dto.dashboard.DashboardSummaryDto;
+import com.assettrack.dto.dashboard.QuickSpareAssetDto;
 import com.assettrack.exception.ResourceNotFoundException;
 import com.assettrack.repository.asset.AssetRepository;
 import org.junit.jupiter.api.Test;
@@ -18,6 +18,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
+import com.assettrack.domain.asset.Asset;
 
 @ExtendWith(MockitoExtension.class)
 class DashboardServiceTest {
@@ -47,7 +48,7 @@ class DashboardServiceTest {
             @Override public Long getCount() { return 8L; }
         };
         AssetRepository.TypeCount tc2 = new AssetRepository.TypeCount() {
-            @Override public AssetType getType() { return AssetType.MONITOR; }
+            @Override public AssetType getType() { return AssetType.SCREEN; }
             @Override public Long getCount() { return 2L; }
         };
         when(assetRepository.countByType()).thenReturn(List.of(tc1, tc2));
@@ -55,8 +56,20 @@ class DashboardServiceTest {
         DashboardSummaryDto summary = dashboardService.getSummary();
 
         assertThat(summary.getTotalAssets()).isEqualTo(10L);
-        assertThat(summary.getStatusDistribution()).containsEntry("AVAILABLE", 6L).containsEntry("ALLOCATED", 4L);
-        assertThat(summary.getTypeDistribution()).containsEntry("LAPTOP", 8L).containsEntry("MONITOR", 2L);
+
+        List<String> statusLabels = summary.getStatusDistribution().getLabels();
+        List<Long> statusData = summary.getStatusDistribution().getData();
+        assertThat(statusLabels).containsExactly("AVAILABLE", "ALLOCATED", "EXPIRED");
+        assertThat(statusData.get(statusLabels.indexOf("AVAILABLE"))).isEqualTo(6L);
+        assertThat(statusData.get(statusLabels.indexOf("ALLOCATED"))).isEqualTo(4L);
+        assertThat(statusData.get(statusLabels.indexOf("EXPIRED"))).isEqualTo(0L);
+
+        List<String> typeLabels = summary.getTypeDistribution().getLabels();
+        List<Long> typeData = summary.getTypeDistribution().getData();
+        assertThat(typeLabels).containsExactly("LAPTOP", "SCREEN", "ACCESSORY");
+        assertThat(typeData.get(typeLabels.indexOf("LAPTOP"))).isEqualTo(8L);
+        assertThat(typeData.get(typeLabels.indexOf("SCREEN"))).isEqualTo(2L);
+        assertThat(typeData.get(typeLabels.indexOf("ACCESSORY"))).isEqualTo(0L);
     }
 
     @Test
@@ -69,9 +82,11 @@ class DashboardServiceTest {
         when(assetRepository.findFirstByTypeAndStatusOrderByCreatedAtAsc(AssetType.LAPTOP, AssetStatus.AVAILABLE))
                 .thenReturn(Optional.of(laptop));
 
-        Asset result = dashboardService.getQuickSpareLaptop();
+        QuickSpareAssetDto result = dashboardService.getQuickSpareLaptop();
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getType()).isEqualTo("LAPTOP");
+        assertThat(result.getStatus()).isEqualTo("AVAILABLE");
     }
 
     @Test

--- a/backend/src/test/java/com/assettrack/service/dashboard/DashboardServiceTest.java
+++ b/backend/src/test/java/com/assettrack/service/dashboard/DashboardServiceTest.java
@@ -1,0 +1,86 @@
+package com.assettrack.service.dashboard;
+
+import com.assettrack.domain.asset.Asset;
+import com.assettrack.domain.asset.AssetStatus;
+import com.assettrack.domain.asset.AssetType;
+import com.assettrack.dto.dashboard.DashboardSummaryDto;
+import com.assettrack.exception.ResourceNotFoundException;
+import com.assettrack.repository.asset.AssetRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardServiceTest {
+
+    @Mock
+    private AssetRepository assetRepository;
+
+    @InjectMocks
+    private DashboardService dashboardService;
+
+    @Test
+    void getSummary_ReturnsCorrectSummary() {
+        when(assetRepository.count()).thenReturn(10L);
+
+        AssetRepository.StatusCount sc1 = new AssetRepository.StatusCount() {
+            @Override public AssetStatus getStatus() { return AssetStatus.AVAILABLE; }
+            @Override public Long getCount() { return 6L; }
+        };
+        AssetRepository.StatusCount sc2 = new AssetRepository.StatusCount() {
+            @Override public AssetStatus getStatus() { return AssetStatus.ALLOCATED; }
+            @Override public Long getCount() { return 4L; }
+        };
+        when(assetRepository.countByStatus()).thenReturn(List.of(sc1, sc2));
+
+        AssetRepository.TypeCount tc1 = new AssetRepository.TypeCount() {
+            @Override public AssetType getType() { return AssetType.LAPTOP; }
+            @Override public Long getCount() { return 8L; }
+        };
+        AssetRepository.TypeCount tc2 = new AssetRepository.TypeCount() {
+            @Override public AssetType getType() { return AssetType.MONITOR; }
+            @Override public Long getCount() { return 2L; }
+        };
+        when(assetRepository.countByType()).thenReturn(List.of(tc1, tc2));
+
+        DashboardSummaryDto summary = dashboardService.getSummary();
+
+        assertThat(summary.getTotalAssets()).isEqualTo(10L);
+        assertThat(summary.getStatusDistribution()).containsEntry("AVAILABLE", 6L).containsEntry("ALLOCATED", 4L);
+        assertThat(summary.getTypeDistribution()).containsEntry("LAPTOP", 8L).containsEntry("MONITOR", 2L);
+    }
+
+    @Test
+    void getQuickSpareLaptop_WhenFound_ReturnsAsset() {
+        Asset laptop = new Asset();
+        laptop.setId(1L);
+        laptop.setType(AssetType.LAPTOP);
+        laptop.setStatus(AssetStatus.AVAILABLE);
+
+        when(assetRepository.findFirstByTypeAndStatusOrderByCreatedAtAsc(AssetType.LAPTOP, AssetStatus.AVAILABLE))
+                .thenReturn(Optional.of(laptop));
+
+        Asset result = dashboardService.getQuickSpareLaptop();
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void getQuickSpareLaptop_WhenNotFound_ThrowsException() {
+        when(assetRepository.findFirstByTypeAndStatusOrderByCreatedAtAsc(AssetType.LAPTOP, AssetStatus.AVAILABLE))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> dashboardService.getQuickSpareLaptop())
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("No available spare laptop found");
+    }
+}


### PR DESCRIPTION
Closes #25

### Description
This PR implements the DashboardService aggregation and quick-spare endpoints. 

### Missing Dependencies & Stubbing
Note: The `Asset` entity required to query asset data was not fully implemented yet. In accordance with the missing dependency protocol, I scaffolded a minimal `@Entity public class Asset` (with `AssetType` and `AssetStatus` enums) so the Dashboard queries compile and run successfully. This must be fully implemented by the assignee of Issue #11 and wired up accordingly.