### PR TITLE
feat(domain): implement Asset & AssetAllocation entities with OpenAPI docs (#11)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -18,6 +18,7 @@
         <java.version>17</java.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <lombok.version>1.18.30</lombok.version>
+        <springdoc.version>2.6.0</springdoc.version>
     </properties>
 
     <dependencies>
@@ -81,6 +82,12 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- SpringDoc OpenAPI (Swagger UI) -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -112,4 +119,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/backend/src/main/java/com/assettrack/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/assettrack/config/OpenApiConfig.java
@@ -1,0 +1,45 @@
+package com.assettrack.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI assetTrackOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("AssetTrack API")
+                        .description("IT Asset Management and Tracking System API. " +
+                                "Provides endpoints for managing assets, allocations, users, " +
+                                "authentication, dashboard analytics, and notifications.")
+                        .version("0.1.0")
+                        .contact(new Contact()
+                                .name("AssetTrack Team")
+                                .email("admin@assettrack.com"))
+                        .license(new License()
+                                .name("MIT License")
+                                .url("https://opensource.org/licenses/MIT")))
+                .servers(List.of(
+                        new Server().url("http://localhost:8080").description("Local Development")))
+                .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+                .components(new Components()
+                        .addSecuritySchemes("Bearer Authentication",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                                        .description("Enter your JWT token")));
+    }
+}

--- a/backend/src/main/java/com/assettrack/controller/asset/AssetActionController.java
+++ b/backend/src/main/java/com/assettrack/controller/asset/AssetActionController.java
@@ -2,6 +2,11 @@ package com.assettrack.controller.asset;
 
 import com.assettrack.dto.dashboard.QuickSpareAssetDto;
 import com.assettrack.service.dashboard.DashboardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,11 +16,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/assets")
 @RequiredArgsConstructor
+@Tag(name = "Assets", description = "Asset management and lookup endpoints")
 public class AssetActionController {
 
     private final DashboardService dashboardService;
 
     @GetMapping("/quick-spare")
+    @Operation(summary = "Get a quick spare laptop", description = "Returns the oldest available laptop asset for quick allocation")
+    @ApiResponse(responseCode = "200", description = "Spare asset found",
+            content = @Content(schema = @Schema(implementation = QuickSpareAssetDto.class)))
+    @ApiResponse(responseCode = "404", description = "No available spare asset")
     public ResponseEntity<QuickSpareAssetDto> getQuickSpareLaptop() {
         return ResponseEntity.ok(dashboardService.getQuickSpareLaptop());
     }

--- a/backend/src/main/java/com/assettrack/controller/auth/AuthController.java
+++ b/backend/src/main/java/com/assettrack/controller/auth/AuthController.java
@@ -4,6 +4,11 @@ import com.assettrack.dto.auth.AuthResponse;
 import com.assettrack.dto.auth.LoginRequest;
 import com.assettrack.dto.auth.SignupRequest;
 import com.assettrack.service.auth.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -15,15 +20,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@Tag(name = "Authentication", description = "User registration and login endpoints")
 public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/register")
+    @Operation(summary = "Register a new user", description = "Creates a new user account and returns a JWT token")
+    @ApiResponse(responseCode = "201", description = "User registered successfully",
+            content = @Content(schema = @Schema(implementation = AuthResponse.class)))
+    @ApiResponse(responseCode = "422", description = "Validation error")
+    @ApiResponse(responseCode = "409", description = "Email already exists")
     public ResponseEntity<AuthResponse> register(@RequestBody @Validated SignupRequest request) {
         AuthResponse response = authService.register(request);
         return ResponseEntity.status(201).body(response);
     }
+
     @PostMapping("/login")
+    @Operation(summary = "Login", description = "Authenticates a user and returns a JWT token")
+    @ApiResponse(responseCode = "200", description = "Login successful",
+            content = @Content(schema = @Schema(implementation = AuthResponse.class)))
+    @ApiResponse(responseCode = "401", description = "Invalid credentials")
     public ResponseEntity<AuthResponse> login(@RequestBody @Validated LoginRequest request) {
         AuthResponse response = authService.login(request);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/assettrack/controller/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/assettrack/controller/dashboard/DashboardController.java
@@ -2,6 +2,11 @@ package com.assettrack.controller.dashboard;
 
 import com.assettrack.dto.dashboard.DashboardSummaryDto;
 import com.assettrack.service.dashboard.DashboardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,11 +16,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/dashboard")
 @RequiredArgsConstructor
+@Tag(name = "Dashboard", description = "Dashboard analytics and summary endpoints")
 public class DashboardController {
 
     private final DashboardService dashboardService;
 
     @GetMapping("/summary")
+    @Operation(summary = "Get dashboard summary", description = "Returns asset counts by status and type for the admin dashboard")
+    @ApiResponse(responseCode = "200", description = "Dashboard summary retrieved",
+            content = @Content(schema = @Schema(implementation = DashboardSummaryDto.class)))
     public ResponseEntity<DashboardSummaryDto> getSummary() {
         return ResponseEntity.ok(dashboardService.getSummary());
     }

--- a/backend/src/main/java/com/assettrack/controller/user/UserController.java
+++ b/backend/src/main/java/com/assettrack/controller/user/UserController.java
@@ -4,6 +4,12 @@ import com.assettrack.dto.user.UpdateEmailRequest;
 import com.assettrack.dto.user.UpdatePasswordRequest;
 import com.assettrack.dto.user.UserResponse;
 import com.assettrack.service.user.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,39 +22,64 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
+@Tag(name = "Users", description = "User management and self-service endpoints")
 public class UserController {
     private final UserService userService;
 
     @GetMapping("/me")
     @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Get my profile", description = "Returns the authenticated user's profile")
+    @ApiResponse(responseCode = "200", description = "Profile retrieved",
+            content = @Content(schema = @Schema(implementation = UserResponse.class)))
+    @ApiResponse(responseCode = "401", description = "Not authenticated")
     public ResponseEntity<UserResponse> getMyProfile(Authentication authentication){
         UserResponse response = userService.getMyProfile(authentication);
         return ResponseEntity.ok(response);
     }
+
     @GetMapping()
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "List all users", description = "Returns a paginated list of all users (Admin only)")
+    @ApiResponse(responseCode = "200", description = "Users retrieved")
+    @ApiResponse(responseCode = "403", description = "Forbidden – Admin role required")
     public ResponseEntity<Page<UserResponse>> getAllUsers(Pageable pageable){
         return ResponseEntity.ok(userService.getAllUsers(pageable));
     }
+
     @GetMapping("/inactive")
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "List inactive users", description = "Returns a paginated list of deactivated users (Admin only)")
+    @ApiResponse(responseCode = "200", description = "Inactive users retrieved")
+    @ApiResponse(responseCode = "403", description = "Forbidden – Admin role required")
     public ResponseEntity<Page<UserResponse>> getInActiveUsers(Pageable pageable){
         return  ResponseEntity.ok(userService.getInactiveUsers(pageable));
     }
+
     @GetMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<UserResponse> getUser(@PathVariable Long id){
+    @Operation(summary = "Get user by ID", description = "Returns a single user by their ID (Admin only)")
+    @ApiResponse(responseCode = "200", description = "User found",
+            content = @Content(schema = @Schema(implementation = UserResponse.class)))
+    @ApiResponse(responseCode = "404", description = "User not found")
+    public ResponseEntity<UserResponse> getUser(@Parameter(description = "User ID") @PathVariable Long id){
         return ResponseEntity.ok(userService.getUserById(id));
     }
 
     @PutMapping("/me/email")
     @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Update my email", description = "Updates the authenticated user's email address")
+    @ApiResponse(responseCode = "200", description = "Email updated",
+            content = @Content(schema = @Schema(implementation = UserResponse.class)))
+    @ApiResponse(responseCode = "409", description = "Email already taken")
     public ResponseEntity<UserResponse> updateEmail(@RequestBody @Validated UpdateEmailRequest request, Authentication authentication){
         return ResponseEntity.ok(userService.updateEmail(request, authentication));
     }
 
     @PutMapping("/me/password")
     @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Update my password", description = "Changes the authenticated user's password")
+    @ApiResponse(responseCode = "204", description = "Password updated")
+    @ApiResponse(responseCode = "400", description = "Invalid current password")
     public ResponseEntity<Void> updatePassword(@RequestBody @Validated UpdatePasswordRequest request,Authentication authentication){
         userService.updatePassword(request, authentication);
         return ResponseEntity.noContent().build();
@@ -56,18 +87,35 @@ public class UserController {
 
     @PutMapping("/{id}/role")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<UserResponse> updateUserRole(@PathVariable Long id, @RequestParam String role, Authentication authentication){
+    @Operation(summary = "Update user role", description = "Changes a user's role (Admin only)")
+    @ApiResponse(responseCode = "200", description = "Role updated",
+            content = @Content(schema = @Schema(implementation = UserResponse.class)))
+    @ApiResponse(responseCode = "404", description = "User not found")
+    @ApiResponse(responseCode = "400", description = "Invalid role")
+    public ResponseEntity<UserResponse> updateUserRole(
+            @Parameter(description = "User ID") @PathVariable Long id,
+            @Parameter(description = "New role (ADMIN, MANAGER, DEVELOPER)") @RequestParam String role,
+            Authentication authentication){
         return ResponseEntity.ok(userService.updateUserRole(id, role, authentication));
     }
 
     @PutMapping("/{id}/status")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<UserResponse> updateUserStatus(@PathVariable Long id, @RequestParam boolean active, Authentication authentication){
+    @Operation(summary = "Update user status", description = "Activates or deactivates a user (Admin only)")
+    @ApiResponse(responseCode = "200", description = "Status updated",
+            content = @Content(schema = @Schema(implementation = UserResponse.class)))
+    @ApiResponse(responseCode = "404", description = "User not found")
+    public ResponseEntity<UserResponse> updateUserStatus(
+            @Parameter(description = "User ID") @PathVariable Long id,
+            @Parameter(description = "Active status") @RequestParam boolean active,
+            Authentication authentication){
         return ResponseEntity.ok(userService.updateUserStatus(id, active, authentication));
     }
 
     @DeleteMapping("/me")
     @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Delete my account", description = "Permanently deletes the authenticated user's account")
+    @ApiResponse(responseCode = "204", description = "Account deleted")
     public ResponseEntity<Void> deleteAccount(Authentication authentication){
         userService.deleteSelf(authentication);
         return ResponseEntity.noContent().build();
@@ -75,7 +123,12 @@ public class UserController {
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<Void> deleteUser(@PathVariable Long id,Authentication authentication){
+    @Operation(summary = "Delete user", description = "Permanently deletes a user by ID (Admin only)")
+    @ApiResponse(responseCode = "204", description = "User deleted")
+    @ApiResponse(responseCode = "404", description = "User not found")
+    public ResponseEntity<Void> deleteUser(
+            @Parameter(description = "User ID") @PathVariable Long id,
+            Authentication authentication){
         userService.deleteUser(id, authentication);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/assettrack/domain/asset/Asset.java
+++ b/backend/src/main/java/com/assettrack/domain/asset/Asset.java
@@ -1,19 +1,23 @@
 package com.assettrack.domain.asset;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Column;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.EnumType;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
+@Table(name = "assets")
 @Data
 @Builder
 @NoArgsConstructor
@@ -27,6 +31,19 @@ public class Asset {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private AssetType type;
+
+    @Column(nullable = false)
+    private String brand;
+
+    @Column(nullable = false)
+    private String model;
+
+    @Column(nullable = false, unique = true)
+    private String serialNumber;
+
+    private LocalDate purchaseDate;
+
+    private LocalDate warrantyExpirationDate;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/backend/src/main/java/com/assettrack/domain/asset/AssetAllocation.java
+++ b/backend/src/main/java/com/assettrack/domain/asset/AssetAllocation.java
@@ -1,0 +1,44 @@
+package com.assettrack.domain.asset;
+
+import com.assettrack.domain.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "asset_allocations")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssetAllocation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "asset_id", nullable = false)
+    private Asset asset;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime checkoutDate;
+
+    private LocalDateTime returnDate;
+}

--- a/backend/src/main/java/com/assettrack/repository/asset/AssetAllocationRepository.java
+++ b/backend/src/main/java/com/assettrack/repository/asset/AssetAllocationRepository.java
@@ -1,0 +1,13 @@
+package com.assettrack.repository.asset;
+
+import com.assettrack.domain.asset.AssetAllocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AssetAllocationRepository extends JpaRepository<AssetAllocation, Long> {
+
+    List<AssetAllocation> findByAssetIdOrderByCheckoutDateDesc(Long assetId);
+}

--- a/backend/src/main/java/com/assettrack/repository/asset/AssetRepository.java
+++ b/backend/src/main/java/com/assettrack/repository/asset/AssetRepository.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 @Repository
 public interface AssetRepository extends JpaRepository<Asset, Long> {
 
+    Optional<Asset> findBySerialNumber(String serialNumber);
+
     @Query("SELECT a.status as status, COUNT(a) as count FROM Asset a GROUP BY a.status")
     List<StatusCount> countByStatus();
 

--- a/backend/src/test/java/com/assettrack/repository/asset/AssetAllocationRepositoryTest.java
+++ b/backend/src/test/java/com/assettrack/repository/asset/AssetAllocationRepositoryTest.java
@@ -1,0 +1,127 @@
+package com.assettrack.repository.asset;
+
+import com.assettrack.domain.asset.Asset;
+import com.assettrack.domain.asset.AssetAllocation;
+import com.assettrack.domain.asset.AssetStatus;
+import com.assettrack.domain.asset.AssetType;
+import com.assettrack.domain.user.Role;
+import com.assettrack.domain.user.User;
+import com.assettrack.repository.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class AssetAllocationRepositoryTest {
+
+    @Autowired
+    private AssetAllocationRepository allocationRepository;
+
+    @Autowired
+    private AssetRepository assetRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Asset testAsset;
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(User.builder()
+                .email("testuser@assettrack.com")
+                .passwordHash("$2a$12$hashed_password")
+                .role(Role.DEVELOPER)
+                .build());
+
+        testAsset = assetRepository.save(Asset.builder()
+                .type(AssetType.LAPTOP)
+                .brand("Apple")
+                .model("MacBook Pro 16")
+                .serialNumber("SN-ALLOC-001")
+                .purchaseDate(LocalDate.of(2025, 3, 1))
+                .warrantyExpirationDate(LocalDate.of(2028, 3, 1))
+                .status(AssetStatus.ALLOCATED)
+                .build());
+    }
+
+    @Test
+    void save_AllocationWithAssetAndUser_PersistsCorrectly() {
+        AssetAllocation allocation = AssetAllocation.builder()
+                .asset(testAsset)
+                .user(testUser)
+                .checkoutDate(LocalDateTime.of(2025, 4, 1, 10, 0))
+                .build();
+
+        AssetAllocation saved = allocationRepository.save(allocation);
+
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getAsset().getId()).isEqualTo(testAsset.getId());
+        assertThat(saved.getUser().getId()).isEqualTo(testUser.getId());
+        assertThat(saved.getCheckoutDate()).isEqualTo(LocalDateTime.of(2025, 4, 1, 10, 0));
+        assertThat(saved.getReturnDate()).isNull();
+    }
+
+    @Test
+    void findByAssetIdOrderByCheckoutDateDesc_ReturnsAllocationsInDescOrder() {
+        AssetAllocation older = allocationRepository.save(AssetAllocation.builder()
+                .asset(testAsset)
+                .user(testUser)
+                .checkoutDate(LocalDateTime.of(2025, 1, 1, 9, 0))
+                .returnDate(LocalDateTime.of(2025, 2, 1, 17, 0))
+                .build());
+
+        AssetAllocation newer = allocationRepository.save(AssetAllocation.builder()
+                .asset(testAsset)
+                .user(testUser)
+                .checkoutDate(LocalDateTime.of(2025, 4, 1, 9, 0))
+                .build());
+
+        List<AssetAllocation> allocations =
+                allocationRepository.findByAssetIdOrderByCheckoutDateDesc(testAsset.getId());
+
+        assertThat(allocations).hasSize(2);
+        assertThat(allocations.get(0).getCheckoutDate()).isAfter(allocations.get(1).getCheckoutDate());
+        assertThat(allocations.get(0).getId()).isEqualTo(newer.getId());
+        assertThat(allocations.get(1).getId()).isEqualTo(older.getId());
+    }
+
+    @Test
+    void findByAssetIdOrderByCheckoutDateDesc_WhenNoAllocations_ReturnsEmptyList() {
+        Asset anotherAsset = assetRepository.save(Asset.builder()
+                .type(AssetType.SCREEN)
+                .brand("Samsung")
+                .model("Odyssey G9")
+                .serialNumber("SN-NO-ALLOC")
+                .status(AssetStatus.AVAILABLE)
+                .build());
+
+        List<AssetAllocation> allocations =
+                allocationRepository.findByAssetIdOrderByCheckoutDateDesc(anotherAsset.getId());
+
+        assertThat(allocations).isEmpty();
+    }
+
+    @Test
+    void allocation_MapsToCorrectUserAndAsset() {
+        AssetAllocation allocation = allocationRepository.save(AssetAllocation.builder()
+                .asset(testAsset)
+                .user(testUser)
+                .checkoutDate(LocalDateTime.now())
+                .build());
+
+        AssetAllocation found = allocationRepository.findById(allocation.getId()).orElseThrow();
+
+        assertThat(found.getAsset().getSerialNumber()).isEqualTo("SN-ALLOC-001");
+        assertThat(found.getAsset().getBrand()).isEqualTo("Apple");
+        assertThat(found.getUser().getEmail()).isEqualTo("testuser@assettrack.com");
+        assertThat(found.getUser().getRole()).isEqualTo(Role.DEVELOPER);
+    }
+}

--- a/backend/src/test/java/com/assettrack/repository/asset/AssetRepositoryTest.java
+++ b/backend/src/test/java/com/assettrack/repository/asset/AssetRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.assettrack.repository.asset;
+
+import com.assettrack.domain.asset.Asset;
+import com.assettrack.domain.asset.AssetStatus;
+import com.assettrack.domain.asset.AssetType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+class AssetRepositoryTest {
+
+    @Autowired
+    private AssetRepository assetRepository;
+
+    private Asset buildAsset(String serialNumber) {
+        return Asset.builder()
+                .type(AssetType.LAPTOP)
+                .brand("Dell")
+                .model("Latitude 5540")
+                .serialNumber(serialNumber)
+                .purchaseDate(LocalDate.of(2025, 1, 15))
+                .warrantyExpirationDate(LocalDate.of(2028, 1, 15))
+                .status(AssetStatus.AVAILABLE)
+                .build();
+    }
+
+    @Test
+    void findBySerialNumber_WhenAssetExists_ReturnsAsset() {
+        assetRepository.save(buildAsset("SN-001"));
+
+        Optional<Asset> result = assetRepository.findBySerialNumber("SN-001");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getSerialNumber()).isEqualTo("SN-001");
+        assertThat(result.get().getBrand()).isEqualTo("Dell");
+        assertThat(result.get().getModel()).isEqualTo("Latitude 5540");
+    }
+
+    @Test
+    void findBySerialNumber_WhenAssetDoesNotExist_ReturnsEmpty() {
+        Optional<Asset> result = assetRepository.findBySerialNumber("NONEXISTENT");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void save_DuplicateSerialNumber_ThrowsDataIntegrityViolationException() {
+        assetRepository.save(buildAsset("SN-DUPLICATE"));
+
+        assertThatThrownBy(() -> {
+            assetRepository.saveAndFlush(buildAsset("SN-DUPLICATE"));
+        }).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void save_AssetWithAllFields_PersistsCorrectly() {
+        Asset asset = Asset.builder()
+                .type(AssetType.SCREEN)
+                .brand("LG")
+                .model("27UK850")
+                .serialNumber("SN-SCREEN-001")
+                .purchaseDate(LocalDate.of(2024, 6, 1))
+                .warrantyExpirationDate(LocalDate.of(2027, 6, 1))
+                .status(AssetStatus.ALLOCATED)
+                .build();
+
+        Asset saved = assetRepository.save(asset);
+
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getType()).isEqualTo(AssetType.SCREEN);
+        assertThat(saved.getBrand()).isEqualTo("LG");
+        assertThat(saved.getModel()).isEqualTo("27UK850");
+        assertThat(saved.getStatus()).isEqualTo(AssetStatus.ALLOCATED);
+        assertThat(saved.getPurchaseDate()).isEqualTo(LocalDate.of(2024, 6, 1));
+        assertThat(saved.getWarrantyExpirationDate()).isEqualTo(LocalDate.of(2027, 6, 1));
+    }
+
+    @Test
+    void save_AssetWithEnumStrings_PersistsCorrectly() {
+        Asset asset = buildAsset("SN-ENUM-TEST");
+        asset.setStatus(AssetStatus.EXPIRED);
+        asset.setType(AssetType.ACCESSORY);
+
+        Asset saved = assetRepository.saveAndFlush(asset);
+
+        Optional<Asset> retrieved = assetRepository.findById(saved.getId());
+        assertThat(retrieved).isPresent();
+        assertThat(retrieved.get().getStatus()).isEqualTo(AssetStatus.EXPIRED);
+        assertThat(retrieved.get().getType()).isEqualTo(AssetType.ACCESSORY);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Issue #11**: Asset and AssetAllocation Entities with full repository layer and OpenAPI documentation.

Closes #11

---

### Changes

#### 1. Domain — `Asset` Entity (Updated)
| Field | Type | Constraints |
|---|---|---|
| `id` | `Long` | `@Id`, `@GeneratedValue(IDENTITY)` |
| `type` | `AssetType` | `@Enumerated(STRING)`, `NOT NULL` |
| `brand` | `String` | `NOT NULL` |
| `model` | `String` | `NOT NULL` |
| `serialNumber` | `String` | `NOT NULL`, **`UNIQUE`** |
| `purchaseDate` | `LocalDate` | nullable |
| `warrantyExpirationDate` | `LocalDate` | nullable |
| `status` | `AssetStatus` | `@Enumerated(STRING)`, `NOT NULL` |
| `createdAt` | `LocalDateTime` | `NOT NULL`, default `now()` |

#### 2. Domain — `AssetAllocation` Entity (New)
| Field | Type | Constraints |
|---|---|---|
| `id` | `Long` | `@Id`, `@GeneratedValue(IDENTITY)` |
| `asset` | `Asset` | `@ManyToOne(LAZY)`, `NOT NULL` |
| `user` | `User` | `@ManyToOne(LAZY)`, `NOT NULL` |
| `checkoutDate` | `LocalDateTime` | `NOT NULL` |
| `returnDate` | `LocalDateTime` | nullable |

#### 3. Repository Layer
- **`AssetRepository`** — Added `findBySerialNumber(String serialNumber)`
- **`AssetAllocationRepository`** (New) — `findByAssetIdOrderByCheckoutDateDesc(Long assetId)`

#### 4. Tests (H2 In-Memory)
- **`AssetRepositoryTest`** — 5 tests covering `findBySerialNumber`, unique constraint on serial number, enum persistence, and full-field save
- **`AssetAllocationRepositoryTest`** — 4 tests covering ManyToOne mapping, ordering, and edge cases

#### 5. OpenAPI / Swagger Documentation
- Added `springdoc-openapi-starter-webmvc-ui` dependency (v2.6.0)
- Created `OpenApiConfig` with JWT Bearer security scheme
- Added `@Tag`, `@Operation`, and `@ApiResponse` annotations to all controllers
- Swagger UI accessible at: `http://localhost:8080/swagger-ui/index.html`
- OpenAPI JSON at: `http://localhost:8080/v3/api-docs`

---

### Acceptance Criteria Checklist
- [x] `Asset` entity with all specified fields
- [x] `AssetAllocation` entity with `@ManyToOne` to `Asset` and `User`
- [x] `@Enumerated(EnumType.STRING)` for `AssetType` and `AssetStatus`
- [x] `serialNumber` unique constraint at DB level
- [x] `AssetRepository.findBySerialNumber()`
- [x] `AssetAllocationRepository.findByAssetIdOrderByCheckoutDateDesc()`
- [x] Repository tests with H2
- [x] `AssetAllocation` correctly maps to both `Asset` and `User`
