### PR TITLE
feat(domain): implement ConditionReport and JPA Specifications for advanced search

### DIFF
--- a/backend/src/main/java/com/assettrack/controller/asset/AssetActionController.java
+++ b/backend/src/main/java/com/assettrack/controller/asset/AssetActionController.java
@@ -1,25 +1,56 @@
 package com.assettrack.controller.asset;
 
+import com.assettrack.domain.asset.AssetStatus;
+import com.assettrack.domain.asset.AssetType;
+import com.assettrack.dto.asset.AssetResponse;
+import com.assettrack.dto.asset.ConditionReportResponse;
+import com.assettrack.dto.asset.CreateConditionReportRequest;
 import com.assettrack.dto.dashboard.QuickSpareAssetDto;
+import com.assettrack.service.asset.AssetService;
 import com.assettrack.service.dashboard.DashboardService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/assets")
 @RequiredArgsConstructor
-@Tag(name = "Assets", description = "Asset management and lookup endpoints")
+@Tag(name = "Assets", description = "Asset management, search, and condition reporting endpoints")
 public class AssetActionController {
 
     private final DashboardService dashboardService;
+    private final AssetService assetService;
+
+    // ──────────────────────────── Asset Search ────────────────────────────
+
+    @GetMapping("/search")
+    @Operation(summary = "Search assets", description = "Dynamic asset search with optional filters for status, type, brand, and serial number. All parameters are optional and composable.")
+    @ApiResponse(responseCode = "200", description = "Search results returned")
+    public ResponseEntity<Page<AssetResponse>> searchAssets(
+            @Parameter(description = "Filter by status (AVAILABLE, ALLOCATED, EXPIRED)")
+            @RequestParam(required = false) AssetStatus status,
+            @Parameter(description = "Filter by type (LAPTOP, SCREEN, ACCESSORY)")
+            @RequestParam(required = false) AssetType type,
+            @Parameter(description = "Filter by brand (case-insensitive partial match)")
+            @RequestParam(required = false) String brand,
+            @Parameter(description = "Filter by exact serial number")
+            @RequestParam(required = false) String serialNumber,
+            Pageable pageable) {
+        return ResponseEntity.ok(assetService.searchAssets(status, type, brand, serialNumber, pageable));
+    }
 
     @GetMapping("/quick-spare")
     @Operation(summary = "Get a quick spare laptop", description = "Returns the oldest available laptop asset for quick allocation")
@@ -28,5 +59,52 @@ public class AssetActionController {
     @ApiResponse(responseCode = "404", description = "No available spare asset")
     public ResponseEntity<QuickSpareAssetDto> getQuickSpareLaptop() {
         return ResponseEntity.ok(dashboardService.getQuickSpareLaptop());
+    }
+
+    // ──────────────────────── Condition Reports ──────────────────────────
+
+    @PostMapping("/condition-reports")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "File a condition report", description = "Creates a new condition report for an asset. The reporter is derived from the authenticated user.")
+    @ApiResponse(responseCode = "201", description = "Condition report created",
+            content = @Content(schema = @Schema(implementation = ConditionReportResponse.class)))
+    @ApiResponse(responseCode = "404", description = "Asset not found")
+    @ApiResponse(responseCode = "422", description = "Validation error")
+    public ResponseEntity<ConditionReportResponse> createConditionReport(
+            @RequestBody @Validated CreateConditionReportRequest request,
+            Authentication authentication) {
+        ConditionReportResponse response = assetService.createConditionReport(request, authentication);
+        return ResponseEntity.status(201).body(response);
+    }
+
+    @GetMapping("/{assetId}/condition-reports")
+    @Operation(summary = "Get condition reports for an asset", description = "Returns all condition reports filed against a specific asset, newest first")
+    @ApiResponse(responseCode = "200", description = "Reports retrieved")
+    @ApiResponse(responseCode = "404", description = "Asset not found")
+    public ResponseEntity<List<ConditionReportResponse>> getReportsByAsset(
+            @Parameter(description = "Asset ID") @PathVariable Long assetId) {
+        return ResponseEntity.ok(assetService.getReportsByAsset(assetId));
+    }
+
+    @GetMapping("/condition-reports/{reportId}")
+    @Operation(summary = "Get a condition report", description = "Returns a single condition report by ID")
+    @ApiResponse(responseCode = "200", description = "Report found",
+            content = @Content(schema = @Schema(implementation = ConditionReportResponse.class)))
+    @ApiResponse(responseCode = "404", description = "Report not found")
+    public ResponseEntity<ConditionReportResponse> getConditionReport(
+            @Parameter(description = "Condition Report ID") @PathVariable Long reportId) {
+        return ResponseEntity.ok(assetService.getReportById(reportId));
+    }
+
+    @PatchMapping("/condition-reports/{reportId}/resolve")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
+    @Operation(summary = "Resolve a condition report", description = "Marks a condition report as RESOLVED (Admin or Manager only)")
+    @ApiResponse(responseCode = "200", description = "Report resolved",
+            content = @Content(schema = @Schema(implementation = ConditionReportResponse.class)))
+    @ApiResponse(responseCode = "404", description = "Report not found")
+    @ApiResponse(responseCode = "403", description = "Forbidden – Admin or Manager role required")
+    public ResponseEntity<ConditionReportResponse> resolveReport(
+            @Parameter(description = "Condition Report ID") @PathVariable Long reportId) {
+        return ResponseEntity.ok(assetService.resolveReport(reportId));
     }
 }

--- a/backend/src/main/java/com/assettrack/domain/asset/ConditionReport.java
+++ b/backend/src/main/java/com/assettrack/domain/asset/ConditionReport.java
@@ -1,0 +1,56 @@
+package com.assettrack.domain.asset;
+
+import com.assettrack.domain.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * Represents a condition/issue report filed against an asset.
+ * Tracks reported issues from creation (OPEN) through resolution (RESOLVED).
+ */
+@Entity
+@Table(name = "condition_reports")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConditionReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "asset_id", nullable = false)
+    private Asset asset;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reported_by", nullable = false)
+    private User reportedBy;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String issueDescription;
+
+    @Column(nullable = false)
+    private LocalDate reportDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private ReportStatus status = ReportStatus.OPEN;
+}

--- a/backend/src/main/java/com/assettrack/domain/asset/ReportStatus.java
+++ b/backend/src/main/java/com/assettrack/domain/asset/ReportStatus.java
@@ -1,0 +1,5 @@
+package com.assettrack.domain.asset;
+
+public enum ReportStatus {
+    OPEN, RESOLVED
+}

--- a/backend/src/main/java/com/assettrack/dto/asset/AssetResponse.java
+++ b/backend/src/main/java/com/assettrack/dto/asset/AssetResponse.java
@@ -1,0 +1,25 @@
+package com.assettrack.dto.asset;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssetResponse {
+    private Long id;
+    private String type;
+    private String brand;
+    private String model;
+    private String serialNumber;
+    private LocalDate purchaseDate;
+    private LocalDate warrantyExpirationDate;
+    private String status;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/assettrack/dto/asset/ConditionReportResponse.java
+++ b/backend/src/main/java/com/assettrack/dto/asset/ConditionReportResponse.java
@@ -1,0 +1,23 @@
+package com.assettrack.dto.asset;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConditionReportResponse {
+    private Long id;
+    private Long assetId;
+    private String assetSerialNumber;
+    private Long reportedById;
+    private String reportedByEmail;
+    private String issueDescription;
+    private LocalDate reportDate;
+    private String status;
+}

--- a/backend/src/main/java/com/assettrack/dto/asset/CreateConditionReportRequest.java
+++ b/backend/src/main/java/com/assettrack/dto/asset/CreateConditionReportRequest.java
@@ -1,0 +1,21 @@
+package com.assettrack.dto.asset;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateConditionReportRequest {
+
+    @NotNull(message = "Asset ID is required")
+    private Long assetId;
+
+    @NotBlank(message = "Issue description is required")
+    private String issueDescription;
+}

--- a/backend/src/main/java/com/assettrack/mapper/asset/AssetMapper.java
+++ b/backend/src/main/java/com/assettrack/mapper/asset/AssetMapper.java
@@ -1,0 +1,23 @@
+package com.assettrack.mapper.asset;
+
+import com.assettrack.domain.asset.Asset;
+import com.assettrack.domain.asset.ConditionReport;
+import com.assettrack.dto.asset.AssetResponse;
+import com.assettrack.dto.asset.ConditionReportResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface AssetMapper {
+
+    @Mapping(target = "type", expression = "java(asset.getType().name())")
+    @Mapping(target = "status", expression = "java(asset.getStatus().name())")
+    AssetResponse toResponse(Asset asset);
+
+    @Mapping(target = "assetId", source = "asset.id")
+    @Mapping(target = "assetSerialNumber", source = "asset.serialNumber")
+    @Mapping(target = "reportedById", source = "reportedBy.id")
+    @Mapping(target = "reportedByEmail", source = "reportedBy.email")
+    @Mapping(target = "status", expression = "java(report.getStatus().name())")
+    ConditionReportResponse toResponse(ConditionReport report);
+}

--- a/backend/src/main/java/com/assettrack/repository/asset/AssetRepository.java
+++ b/backend/src/main/java/com/assettrack/repository/asset/AssetRepository.java
@@ -4,6 +4,7 @@ import com.assettrack.domain.asset.Asset;
 import com.assettrack.domain.asset.AssetStatus;
 import com.assettrack.domain.asset.AssetType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -11,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface AssetRepository extends JpaRepository<Asset, Long> {
+public interface AssetRepository extends JpaRepository<Asset, Long>, JpaSpecificationExecutor<Asset> {
 
     Optional<Asset> findBySerialNumber(String serialNumber);
 

--- a/backend/src/main/java/com/assettrack/repository/asset/AssetSpecifications.java
+++ b/backend/src/main/java/com/assettrack/repository/asset/AssetSpecifications.java
@@ -1,0 +1,65 @@
+package com.assettrack.repository.asset;
+
+import com.assettrack.domain.asset.Asset;
+import com.assettrack.domain.asset.AssetStatus;
+import com.assettrack.domain.asset.AssetType;
+import org.springframework.data.jpa.domain.Specification;
+
+/**
+ * JPA Specifications for building dynamic, composable queries against the Asset entity.
+ * <p>
+ * Each method returns a null-safe {@link Specification}: when a filter value is {@code null},
+ * the specification evaluates to a tautology (always-true predicate), making it safe to
+ * chain with {@code Specification.where(...).and(...)} without null checks at the call site.
+ * <p>
+ * Example usage:
+ * <pre>
+ * Specification&lt;Asset&gt; spec = Specification
+ *     .where(AssetSpecifications.hasStatus(AssetStatus.AVAILABLE))
+ *     .and(AssetSpecifications.hasBrand("Dell"));
+ *
+ * Page&lt;Asset&gt; results = assetRepository.findAll(spec, pageable);
+ * </pre>
+ */
+public final class AssetSpecifications {
+
+    private AssetSpecifications() {
+        // utility class — no instantiation
+    }
+
+    /**
+     * Filters assets by exact status match.
+     */
+    public static Specification<Asset> hasStatus(AssetStatus status) {
+        return (root, query, cb) ->
+                status == null ? cb.conjunction() : cb.equal(root.get("status"), status);
+    }
+
+    /**
+     * Filters assets by exact type match.
+     */
+    public static Specification<Asset> hasType(AssetType type) {
+        return (root, query, cb) ->
+                type == null ? cb.conjunction() : cb.equal(root.get("type"), type);
+    }
+
+    /**
+     * Filters assets by case-insensitive partial brand match (LIKE %brand%).
+     */
+    public static Specification<Asset> hasBrand(String brand) {
+        return (root, query, cb) ->
+                brand == null || brand.isBlank()
+                        ? cb.conjunction()
+                        : cb.like(cb.lower(root.get("brand")), "%" + brand.toLowerCase() + "%");
+    }
+
+    /**
+     * Filters assets by exact serial number match.
+     */
+    public static Specification<Asset> hasSerialNumber(String serialNumber) {
+        return (root, query, cb) ->
+                serialNumber == null || serialNumber.isBlank()
+                        ? cb.conjunction()
+                        : cb.equal(root.get("serialNumber"), serialNumber);
+    }
+}

--- a/backend/src/main/java/com/assettrack/repository/asset/ConditionReportRepository.java
+++ b/backend/src/main/java/com/assettrack/repository/asset/ConditionReportRepository.java
@@ -1,0 +1,18 @@
+package com.assettrack.repository.asset;
+
+import com.assettrack.domain.asset.ConditionReport;
+import com.assettrack.domain.asset.ReportStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ConditionReportRepository extends JpaRepository<ConditionReport, Long> {
+
+    List<ConditionReport> findByAssetIdOrderByReportDateDesc(Long assetId);
+
+    List<ConditionReport> findByReportedByIdOrderByReportDateDesc(Long userId);
+
+    List<ConditionReport> findByStatus(ReportStatus status);
+}

--- a/backend/src/main/java/com/assettrack/service/asset/AssetService.java
+++ b/backend/src/main/java/com/assettrack/service/asset/AssetService.java
@@ -1,0 +1,135 @@
+package com.assettrack.service.asset;
+
+import com.assettrack.domain.asset.Asset;
+import com.assettrack.domain.asset.AssetStatus;
+import com.assettrack.domain.asset.AssetType;
+import com.assettrack.domain.asset.ConditionReport;
+import com.assettrack.domain.asset.ReportStatus;
+import com.assettrack.domain.user.User;
+import com.assettrack.dto.asset.AssetResponse;
+import com.assettrack.dto.asset.ConditionReportResponse;
+import com.assettrack.dto.asset.CreateConditionReportRequest;
+import com.assettrack.exception.ResourceNotFoundException;
+import com.assettrack.mapper.asset.AssetMapper;
+import com.assettrack.repository.asset.AssetRepository;
+import com.assettrack.repository.asset.AssetSpecifications;
+import com.assettrack.repository.asset.ConditionReportRepository;
+import com.assettrack.repository.user.UserRepository;
+import com.assettrack.security.util.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Service layer for asset search and condition reporting.
+ */
+@Service
+@RequiredArgsConstructor
+public class AssetService {
+
+    private final AssetRepository assetRepository;
+    private final ConditionReportRepository conditionReportRepository;
+    private final UserRepository userRepository;
+    private final AssetMapper assetMapper;
+    private final SecurityUtils securityUtils;
+
+    // ──────────────────────────── Asset Search ────────────────────────────
+
+    /**
+     * Dynamic asset search using JPA Specifications.
+     * All parameters are optional; {@code null} values are ignored.
+     *
+     * @param status       filter by asset status
+     * @param type         filter by asset type
+     * @param brand        filter by brand (case-insensitive partial match)
+     * @param serialNumber filter by exact serial number
+     * @param pageable     pagination and sorting
+     * @return page of matching assets
+     */
+    @Transactional(readOnly = true)
+    public Page<AssetResponse> searchAssets(AssetStatus status, AssetType type,
+                                            String brand, String serialNumber,
+                                            Pageable pageable) {
+        Specification<Asset> spec = Specification
+                .where(AssetSpecifications.hasStatus(status))
+                .and(AssetSpecifications.hasType(type))
+                .and(AssetSpecifications.hasBrand(brand))
+                .and(AssetSpecifications.hasSerialNumber(serialNumber));
+
+        return assetRepository.findAll(spec, pageable).map(assetMapper::toResponse);
+    }
+
+    // ──────────────────────── Condition Reports ──────────────────────────
+
+    /**
+     * Creates a condition report for an asset.
+     * The reporter is automatically derived from the current JWT.
+     */
+    @Transactional
+    public ConditionReportResponse createConditionReport(CreateConditionReportRequest request,
+                                                          Authentication authentication) {
+        Long userId = securityUtils.getCurrentUserId(authentication);
+
+        Asset asset = assetRepository.findById(request.getAssetId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Asset not found with id: " + request.getAssetId()));
+
+        User reporter = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "User not found with id: " + userId));
+
+        ConditionReport report = ConditionReport.builder()
+                .asset(asset)
+                .reportedBy(reporter)
+                .issueDescription(request.getIssueDescription())
+                .reportDate(LocalDate.now())
+                .status(ReportStatus.OPEN)
+                .build();
+
+        return assetMapper.toResponse(conditionReportRepository.save(report));
+    }
+
+    /**
+     * Returns all condition reports for a specific asset, newest first.
+     */
+    @Transactional(readOnly = true)
+    public List<ConditionReportResponse> getReportsByAsset(Long assetId) {
+        if (!assetRepository.existsById(assetId)) {
+            throw new ResourceNotFoundException("Asset not found with id: " + assetId);
+        }
+        return conditionReportRepository.findByAssetIdOrderByReportDateDesc(assetId)
+                .stream()
+                .map(assetMapper::toResponse)
+                .toList();
+    }
+
+    /**
+     * Returns a single condition report by ID.
+     */
+    @Transactional(readOnly = true)
+    public ConditionReportResponse getReportById(Long reportId) {
+        ConditionReport report = conditionReportRepository.findById(reportId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Condition report not found with id: " + reportId));
+        return assetMapper.toResponse(report);
+    }
+
+    /**
+     * Resolves an open condition report.
+     */
+    @Transactional
+    public ConditionReportResponse resolveReport(Long reportId) {
+        ConditionReport report = conditionReportRepository.findById(reportId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Condition report not found with id: " + reportId));
+        report.setStatus(ReportStatus.RESOLVED);
+        return assetMapper.toResponse(conditionReportRepository.save(report));
+    }
+}

--- a/backend/src/test/java/com/assettrack/repository/asset/AssetSpecificationsTest.java
+++ b/backend/src/test/java/com/assettrack/repository/asset/AssetSpecificationsTest.java
@@ -1,0 +1,148 @@
+package com.assettrack.repository.asset;
+
+import com.assettrack.domain.asset.Asset;
+import com.assettrack.domain.asset.AssetStatus;
+import com.assettrack.domain.asset.AssetType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class AssetSpecificationsTest {
+
+    @Autowired
+    private AssetRepository assetRepository;
+
+    @BeforeEach
+    void setUp() {
+        assetRepository.save(Asset.builder()
+                .type(AssetType.LAPTOP).brand("Dell").model("Latitude 5540")
+                .serialNumber("SN-SPEC-001").status(AssetStatus.AVAILABLE)
+                .purchaseDate(LocalDate.of(2025, 1, 1))
+                .build());
+
+        assetRepository.save(Asset.builder()
+                .type(AssetType.LAPTOP).brand("Apple").model("MacBook Pro 16")
+                .serialNumber("SN-SPEC-002").status(AssetStatus.ALLOCATED)
+                .purchaseDate(LocalDate.of(2025, 2, 1))
+                .build());
+
+        assetRepository.save(Asset.builder()
+                .type(AssetType.SCREEN).brand("Dell").model("U2723QE")
+                .serialNumber("SN-SPEC-003").status(AssetStatus.AVAILABLE)
+                .purchaseDate(LocalDate.of(2025, 3, 1))
+                .build());
+
+        assetRepository.save(Asset.builder()
+                .type(AssetType.ACCESSORY).brand("Logitech").model("MX Master 3")
+                .serialNumber("SN-SPEC-004").status(AssetStatus.EXPIRED)
+                .purchaseDate(LocalDate.of(2023, 6, 1))
+                .build());
+    }
+
+    @Test
+    void hasStatus_FiltersCorrectly() {
+        Specification<Asset> spec = AssetSpecifications.hasStatus(AssetStatus.AVAILABLE);
+        Page<Asset> results = assetRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(results.getContent()).hasSize(2);
+        assertThat(results.getContent()).allMatch(a -> a.getStatus() == AssetStatus.AVAILABLE);
+    }
+
+    @Test
+    void hasType_FiltersCorrectly() {
+        Specification<Asset> spec = AssetSpecifications.hasType(AssetType.LAPTOP);
+        Page<Asset> results = assetRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(results.getContent()).hasSize(2);
+        assertThat(results.getContent()).allMatch(a -> a.getType() == AssetType.LAPTOP);
+    }
+
+    @Test
+    void hasBrand_CaseInsensitivePartialMatch() {
+        Specification<Asset> spec = AssetSpecifications.hasBrand("dell");
+        Page<Asset> results = assetRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(results.getContent()).hasSize(2);
+        assertThat(results.getContent()).allMatch(a -> a.getBrand().equalsIgnoreCase("Dell"));
+    }
+
+    @Test
+    void hasSerialNumber_ExactMatch() {
+        Specification<Asset> spec = AssetSpecifications.hasSerialNumber("SN-SPEC-002");
+        Page<Asset> results = assetRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(results.getContent()).hasSize(1);
+        assertThat(results.getContent().get(0).getBrand()).isEqualTo("Apple");
+    }
+
+    @Test
+    void combinedFilters_StatusAndType() {
+        Specification<Asset> spec = Specification
+                .where(AssetSpecifications.hasStatus(AssetStatus.AVAILABLE))
+                .and(AssetSpecifications.hasType(AssetType.LAPTOP));
+
+        Page<Asset> results = assetRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(results.getContent()).hasSize(1);
+        assertThat(results.getContent().get(0).getBrand()).isEqualTo("Dell");
+        assertThat(results.getContent().get(0).getSerialNumber()).isEqualTo("SN-SPEC-001");
+    }
+
+    @Test
+    void combinedFilters_BrandAndStatus() {
+        Specification<Asset> spec = Specification
+                .where(AssetSpecifications.hasBrand("Dell"))
+                .and(AssetSpecifications.hasStatus(AssetStatus.AVAILABLE));
+
+        Page<Asset> results = assetRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(results.getContent()).hasSize(2);
+    }
+
+    @Test
+    void combinedFilters_AllFilters() {
+        Specification<Asset> spec = Specification
+                .where(AssetSpecifications.hasStatus(AssetStatus.AVAILABLE))
+                .and(AssetSpecifications.hasType(AssetType.SCREEN))
+                .and(AssetSpecifications.hasBrand("dell"))
+                .and(AssetSpecifications.hasSerialNumber("SN-SPEC-003"));
+
+        Page<Asset> results = assetRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(results.getContent()).hasSize(1);
+        assertThat(results.getContent().get(0).getModel()).isEqualTo("U2723QE");
+    }
+
+    @Test
+    void nullFilters_ReturnAllAssets() {
+        Specification<Asset> spec = Specification
+                .where(AssetSpecifications.hasStatus(null))
+                .and(AssetSpecifications.hasType(null))
+                .and(AssetSpecifications.hasBrand(null))
+                .and(AssetSpecifications.hasSerialNumber(null));
+
+        Page<Asset> results = assetRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(results.getContent()).hasSize(4);
+    }
+
+    @Test
+    void noMatchingResults_ReturnsEmptyPage() {
+        Specification<Asset> spec = Specification
+                .where(AssetSpecifications.hasBrand("NonExistentBrand"));
+
+        Page<Asset> results = assetRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(results.getContent()).isEmpty();
+        assertThat(results.getTotalElements()).isZero();
+    }
+}

--- a/backend/src/test/java/com/assettrack/repository/asset/ConditionReportRepositoryTest.java
+++ b/backend/src/test/java/com/assettrack/repository/asset/ConditionReportRepositoryTest.java
@@ -1,0 +1,150 @@
+package com.assettrack.repository.asset;
+
+import com.assettrack.domain.asset.Asset;
+import com.assettrack.domain.asset.AssetStatus;
+import com.assettrack.domain.asset.AssetType;
+import com.assettrack.domain.asset.ConditionReport;
+import com.assettrack.domain.asset.ReportStatus;
+import com.assettrack.domain.user.Role;
+import com.assettrack.domain.user.User;
+import com.assettrack.repository.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class ConditionReportRepositoryTest {
+
+    @Autowired
+    private ConditionReportRepository reportRepository;
+
+    @Autowired
+    private AssetRepository assetRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Asset testAsset;
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = userRepository.save(User.builder()
+                .email("reporter@assettrack.com")
+                .passwordHash("$2a$12$hashed_password")
+                .role(Role.DEVELOPER)
+                .build());
+
+        testAsset = assetRepository.save(Asset.builder()
+                .type(AssetType.LAPTOP)
+                .brand("Dell")
+                .model("Latitude 5540")
+                .serialNumber("SN-CR-001")
+                .purchaseDate(LocalDate.of(2025, 1, 1))
+                .status(AssetStatus.ALLOCATED)
+                .build());
+    }
+
+    @Test
+    void save_ConditionReport_PersistsCorrectly() {
+        ConditionReport report = ConditionReport.builder()
+                .asset(testAsset)
+                .reportedBy(testUser)
+                .issueDescription("Screen flickering under load")
+                .reportDate(LocalDate.of(2025, 5, 1))
+                .status(ReportStatus.OPEN)
+                .build();
+
+        ConditionReport saved = reportRepository.save(report);
+
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getAsset().getId()).isEqualTo(testAsset.getId());
+        assertThat(saved.getReportedBy().getId()).isEqualTo(testUser.getId());
+        assertThat(saved.getIssueDescription()).isEqualTo("Screen flickering under load");
+        assertThat(saved.getStatus()).isEqualTo(ReportStatus.OPEN);
+    }
+
+    @Test
+    void findByAssetIdOrderByReportDateDesc_ReturnsReportsNewestFirst() {
+        reportRepository.save(ConditionReport.builder()
+                .asset(testAsset).reportedBy(testUser)
+                .issueDescription("Old issue")
+                .reportDate(LocalDate.of(2025, 1, 1))
+                .build());
+
+        reportRepository.save(ConditionReport.builder()
+                .asset(testAsset).reportedBy(testUser)
+                .issueDescription("Recent issue")
+                .reportDate(LocalDate.of(2025, 5, 1))
+                .build());
+
+        List<ConditionReport> reports =
+                reportRepository.findByAssetIdOrderByReportDateDesc(testAsset.getId());
+
+        assertThat(reports).hasSize(2);
+        assertThat(reports.get(0).getReportDate()).isAfter(reports.get(1).getReportDate());
+        assertThat(reports.get(0).getIssueDescription()).isEqualTo("Recent issue");
+    }
+
+    @Test
+    void findByReportedByIdOrderByReportDateDesc_ReturnsUserReports() {
+        reportRepository.save(ConditionReport.builder()
+                .asset(testAsset).reportedBy(testUser)
+                .issueDescription("Keyboard malfunction")
+                .reportDate(LocalDate.now())
+                .build());
+
+        List<ConditionReport> reports =
+                reportRepository.findByReportedByIdOrderByReportDateDesc(testUser.getId());
+
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(0).getReportedBy().getEmail()).isEqualTo("reporter@assettrack.com");
+    }
+
+    @Test
+    void findByStatus_FiltersCorrectly() {
+        reportRepository.save(ConditionReport.builder()
+                .asset(testAsset).reportedBy(testUser)
+                .issueDescription("Open issue")
+                .reportDate(LocalDate.now())
+                .status(ReportStatus.OPEN)
+                .build());
+
+        reportRepository.save(ConditionReport.builder()
+                .asset(testAsset).reportedBy(testUser)
+                .issueDescription("Resolved issue")
+                .reportDate(LocalDate.now())
+                .status(ReportStatus.RESOLVED)
+                .build());
+
+        List<ConditionReport> openReports = reportRepository.findByStatus(ReportStatus.OPEN);
+        List<ConditionReport> resolvedReports = reportRepository.findByStatus(ReportStatus.RESOLVED);
+
+        assertThat(openReports).hasSize(1);
+        assertThat(openReports.get(0).getIssueDescription()).isEqualTo("Open issue");
+        assertThat(resolvedReports).hasSize(1);
+        assertThat(resolvedReports.get(0).getIssueDescription()).isEqualTo("Resolved issue");
+    }
+
+    @Test
+    void conditionReport_MapsToCorrectAssetAndUser() {
+        ConditionReport report = reportRepository.save(ConditionReport.builder()
+                .asset(testAsset).reportedBy(testUser)
+                .issueDescription("Battery drain issue")
+                .reportDate(LocalDate.now())
+                .build());
+
+        ConditionReport found = reportRepository.findById(report.getId()).orElseThrow();
+
+        assertThat(found.getAsset().getSerialNumber()).isEqualTo("SN-CR-001");
+        assertThat(found.getAsset().getBrand()).isEqualTo("Dell");
+        assertThat(found.getReportedBy().getEmail()).isEqualTo("reporter@assettrack.com");
+        assertThat(found.getReportedBy().getRole()).isEqualTo(Role.DEVELOPER);
+    }
+}


### PR DESCRIPTION
Resolves #20

### Changes Made:
- **ConditionReport Entity:** Created `ConditionReport` entity with `@ManyToOne` relationships to `Asset` and `User` (reporter). Uses a new `ReportStatus` enum (`OPEN`, `RESOLVED`).
- **AssetSpecifications:** Implemented `AssetSpecifications` using the JPA Criteria API to enable dynamic, null-safe filtering by `status`, `type`, `brand` (case-insensitive partial match), and `serialNumber` (exact match).
- **AssetRepository:** Updated to extend `JpaSpecificationExecutor<Asset>` to support dynamic queries.
- **Service & Controllers:** Created `AssetService` to handle search logic and condition report CRUD. Enhanced `AssetActionController` with endpoints for `/api/assets/search`, creating reports, retrieving reports by asset, retrieving a single report, and resolving a report (Admin/Manager only).
- **Tests:** Added comprehensive integration tests (`AssetSpecificationsTest` and `ConditionReportRepositoryTest`) using an H2 in-memory database to verify filtering logic and entity relationships.
- **DTOs & Mappers:** Implemented necessary DTOs and updated MapStruct configuration for proper enum-to-string mapping and nested entity flattening.