### PR TITLE
refactor: migrate entity IDs to UUID and update API base path to v1

### DIFF
--- a/backend/src/main/java/com/assettrack/controller/asset/AssetActionController.java
+++ b/backend/src/main/java/com/assettrack/controller/asset/AssetActionController.java
@@ -16,10 +16,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/assets")
+@RequestMapping("/search/assets")
 @RequiredArgsConstructor
 @Tag(name = "Assets", description = "Asset management and search endpoints")
 public class AssetActionController {
@@ -29,7 +30,8 @@ public class AssetActionController {
 
     // ──────────────────────────── Asset Search ────────────────────────────
 
-    @GetMapping("/search")
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Search assets", description = "Dynamic asset search with optional filters for status, type, brand, and serial number. All parameters are optional and composable.")
     @ApiResponse(responseCode = "200", description = "Search results returned")
     public ResponseEntity<Page<AssetResponse>> searchAssets(
@@ -45,7 +47,8 @@ public class AssetActionController {
         return ResponseEntity.ok(assetService.searchAssets(status, type, brand, serialNumber, pageable));
     }
 
-    @GetMapping("/quick-spare")
+    @GetMapping("/spare-laptop")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Get a quick spare laptop", description = "Returns the oldest available laptop asset for quick allocation")
     @ApiResponse(responseCode = "200", description = "Spare asset found",
             content = @Content(schema = @Schema(implementation = QuickSpareAssetDto.class)))

--- a/backend/src/main/java/com/assettrack/controller/asset/ConditionController.java
+++ b/backend/src/main/java/com/assettrack/controller/asset/ConditionController.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/assets")
+@RequestMapping("/assets")
 @RequiredArgsConstructor
 @Tag(name = "Condition Reports", description = "Asset condition reporting endpoints")
 public class ConditionController {
@@ -43,7 +43,7 @@ public class ConditionController {
     @ApiResponse(responseCode = "404", description = "Asset not found")
     @ApiResponse(responseCode = "422", description = "Validation error")
     public ResponseEntity<ConditionReportResponse> reportAssetCondition(
-            @Parameter(description = "Asset ID") @PathVariable Long assetId,
+            @Parameter(description = "Asset ID") @PathVariable java.util.UUID assetId,
             @RequestBody @Validated ReportConditionRequest request,
             Authentication authentication) {
         ConditionReportResponse response = assetService.createConditionReport(
@@ -82,7 +82,7 @@ public class ConditionController {
     @ApiResponse(responseCode = "200", description = "Reports retrieved")
     @ApiResponse(responseCode = "404", description = "Asset not found")
     public ResponseEntity<List<ConditionReportResponse>> getReportsByAsset(
-            @Parameter(description = "Asset ID") @PathVariable Long assetId,
+            @Parameter(description = "Asset ID") @PathVariable java.util.UUID assetId,
             Authentication authentication) {
         return ResponseEntity.ok(assetService.getReportsByAsset(assetId, authentication));
     }
@@ -95,7 +95,7 @@ public class ConditionController {
     @ApiResponse(responseCode = "403", description = "Forbidden when a regular user does not own the report")
     @ApiResponse(responseCode = "404", description = "Report not found")
     public ResponseEntity<ConditionReportResponse> getConditionReport(
-            @Parameter(description = "Condition Report ID") @PathVariable Long reportId,
+            @Parameter(description = "Condition Report ID") @PathVariable java.util.UUID reportId,
             Authentication authentication) {
         return ResponseEntity.ok(assetService.getReportById(reportId, authentication));
     }
@@ -108,7 +108,7 @@ public class ConditionController {
     @ApiResponse(responseCode = "404", description = "Report not found")
     @ApiResponse(responseCode = "403", description = "Forbidden when Admin or Manager role is missing")
     public ResponseEntity<ConditionReportResponse> resolveReport(
-            @Parameter(description = "Condition Report ID") @PathVariable Long reportId) {
+            @Parameter(description = "Condition Report ID") @PathVariable java.util.UUID reportId) {
         return ResponseEntity.ok(assetService.resolveReport(reportId));
     }
 }

--- a/backend/src/main/java/com/assettrack/controller/auth/AuthController.java
+++ b/backend/src/main/java/com/assettrack/controller/auth/AuthController.java
@@ -19,12 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/auth")
+@RequestMapping("/auth")
 @Tag(name = "Authentication", description = "User registration and login endpoints")
 public class AuthController {
     private final AuthService authService;
 
-    @PostMapping("/register")
+    @PostMapping("/signup")
     @Operation(summary = "Register a new user", description = "Creates a new user account and returns a JWT token")
     @ApiResponse(responseCode = "201", description = "User registered successfully",
             content = @Content(schema = @Schema(implementation = AuthResponse.class)))

--- a/backend/src/main/java/com/assettrack/controller/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/assettrack/controller/dashboard/DashboardController.java
@@ -9,19 +9,21 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/dashboard")
+@RequestMapping("/dashboard")
 @RequiredArgsConstructor
 @Tag(name = "Dashboard", description = "Dashboard analytics and summary endpoints")
 public class DashboardController {
 
     private final DashboardService dashboardService;
 
-    @GetMapping("/summary")
+    @GetMapping("/inventory")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER')")
     @Operation(summary = "Get dashboard summary", description = "Returns asset counts by status and type for the admin dashboard")
     @ApiResponse(responseCode = "200", description = "Dashboard summary retrieved",
             content = @Content(schema = @Schema(implementation = DashboardSummaryDto.class)))

--- a/backend/src/main/java/com/assettrack/controller/notification/NotificationController.java
+++ b/backend/src/main/java/com/assettrack/controller/notification/NotificationController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/notifications")
+@RequestMapping("/notifications")
 @RequiredArgsConstructor
 @Tag(name = "Notifications", description = "In-app notification endpoints")
 public class NotificationController {
@@ -42,7 +42,7 @@ public class NotificationController {
             content = @Content(schema = @Schema(implementation = NotificationResponse.class)))
     @ApiResponse(responseCode = "404", description = "Notification not found")
     public ResponseEntity<NotificationResponse> markAsRead(
-            @PathVariable Long notificationId,
+            @PathVariable java.util.UUID notificationId,
             Authentication authentication) {
         return ResponseEntity.ok(notificationService.markAsRead(notificationId, authentication));
     }

--- a/backend/src/main/java/com/assettrack/controller/user/UserController.java
+++ b/backend/src/main/java/com/assettrack/controller/user/UserController.java
@@ -21,12 +21,11 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users")
 @Tag(name = "Users", description = "User management and self-service endpoints")
 public class UserController {
     private final UserService userService;
 
-    @GetMapping("/me")
+    @GetMapping("/auth/me")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Get my profile", description = "Returns the authenticated user's profile")
     @ApiResponse(responseCode = "200", description = "Profile retrieved",
@@ -37,7 +36,7 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping()
+    @GetMapping("/users")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "List all users", description = "Returns a paginated list of all users (Admin only)")
     @ApiResponse(responseCode = "200", description = "Users retrieved")
@@ -46,7 +45,7 @@ public class UserController {
         return ResponseEntity.ok(userService.getAllUsers(pageable));
     }
 
-    @GetMapping("/inactive")
+    @GetMapping("/users/inactive")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "List inactive users", description = "Returns a paginated list of deactivated users (Admin only)")
     @ApiResponse(responseCode = "200", description = "Inactive users retrieved")
@@ -55,17 +54,17 @@ public class UserController {
         return  ResponseEntity.ok(userService.getInactiveUsers(pageable));
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/users/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Get user by ID", description = "Returns a single user by their ID (Admin only)")
     @ApiResponse(responseCode = "200", description = "User found",
             content = @Content(schema = @Schema(implementation = UserResponse.class)))
     @ApiResponse(responseCode = "404", description = "User not found")
-    public ResponseEntity<UserResponse> getUser(@Parameter(description = "User ID") @PathVariable Long id){
+    public ResponseEntity<UserResponse> getUser(@Parameter(description = "User ID") @PathVariable java.util.UUID id){
         return ResponseEntity.ok(userService.getUserById(id));
     }
 
-    @PutMapping("/me/email")
+    @PutMapping("/auth/me/email")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Update my email", description = "Updates the authenticated user's email address")
     @ApiResponse(responseCode = "200", description = "Email updated",
@@ -75,7 +74,7 @@ public class UserController {
         return ResponseEntity.ok(userService.updateEmail(request, authentication));
     }
 
-    @PutMapping("/me/password")
+    @PutMapping("/auth/me/password")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Update my password", description = "Changes the authenticated user's password")
     @ApiResponse(responseCode = "204", description = "Password updated")
@@ -85,7 +84,7 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
-    @PutMapping("/{id}/role")
+    @PutMapping("/users/{id}/role")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update user role", description = "Changes a user's role (Admin only)")
     @ApiResponse(responseCode = "200", description = "Role updated",
@@ -93,26 +92,26 @@ public class UserController {
     @ApiResponse(responseCode = "404", description = "User not found")
     @ApiResponse(responseCode = "400", description = "Invalid role")
     public ResponseEntity<UserResponse> updateUserRole(
-            @Parameter(description = "User ID") @PathVariable Long id,
+            @Parameter(description = "User ID") @PathVariable java.util.UUID id,
             @Parameter(description = "New role (ADMIN, MANAGER, DEVELOPER)") @RequestParam String role,
             Authentication authentication){
         return ResponseEntity.ok(userService.updateUserRole(id, role, authentication));
     }
 
-    @PutMapping("/{id}/status")
+    @PutMapping("/users/{id}/status")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update user status", description = "Activates or deactivates a user (Admin only)")
     @ApiResponse(responseCode = "200", description = "Status updated",
             content = @Content(schema = @Schema(implementation = UserResponse.class)))
     @ApiResponse(responseCode = "404", description = "User not found")
     public ResponseEntity<UserResponse> updateUserStatus(
-            @Parameter(description = "User ID") @PathVariable Long id,
+            @Parameter(description = "User ID") @PathVariable java.util.UUID id,
             @Parameter(description = "Active status") @RequestParam boolean active,
             Authentication authentication){
         return ResponseEntity.ok(userService.updateUserStatus(id, active, authentication));
     }
 
-    @DeleteMapping("/me")
+    @DeleteMapping("/auth/me")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Delete my account", description = "Permanently deletes the authenticated user's account")
     @ApiResponse(responseCode = "204", description = "Account deleted")
@@ -121,13 +120,13 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/users/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Delete user", description = "Permanently deletes a user by ID (Admin only)")
     @ApiResponse(responseCode = "204", description = "User deleted")
     @ApiResponse(responseCode = "404", description = "User not found")
     public ResponseEntity<Void> deleteUser(
-            @Parameter(description = "User ID") @PathVariable Long id,
+            @Parameter(description = "User ID") @PathVariable java.util.UUID id,
             Authentication authentication){
         userService.deleteUser(id, authentication);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/assettrack/domain/asset/Asset.java
+++ b/backend/src/main/java/com/assettrack/domain/asset/Asset.java
@@ -25,8 +25,8 @@ import java.time.LocalDateTime;
 public class Asset {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.UUID)
+    private java.util.UUID id;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -52,4 +52,20 @@ public class Asset {
     @Column(nullable = false)
     @Builder.Default
     private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @jakarta.persistence.PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @jakarta.persistence.PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/com/assettrack/domain/asset/AssetAllocation.java
+++ b/backend/src/main/java/com/assettrack/domain/asset/AssetAllocation.java
@@ -26,8 +26,8 @@ import java.time.LocalDateTime;
 public class AssetAllocation {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.UUID)
+    private java.util.UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "asset_id", nullable = false)

--- a/backend/src/main/java/com/assettrack/domain/asset/ConditionReport.java
+++ b/backend/src/main/java/com/assettrack/domain/asset/ConditionReport.java
@@ -32,8 +32,8 @@ import java.time.LocalDate;
 public class ConditionReport {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.UUID)
+    private java.util.UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "asset_id", nullable = false)

--- a/backend/src/main/java/com/assettrack/domain/notification/Notification.java
+++ b/backend/src/main/java/com/assettrack/domain/notification/Notification.java
@@ -19,8 +19,8 @@ import java.time.LocalDateTime;
 public class Notification {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.UUID)
+    private java.util.UUID id;
 
     @Column(nullable = false)
     private String recipient;

--- a/backend/src/main/java/com/assettrack/domain/user/User.java
+++ b/backend/src/main/java/com/assettrack/domain/user/User.java
@@ -12,14 +12,20 @@ import java.time.LocalDateTime;
 @Builder
 public class User {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.UUID)
+    private java.util.UUID id;
     
     @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false)
     private String passwordHash;
+
+    @Column(name = "first_name")
+    private String firstName;
+
+    @Column(name = "last_name")
+    private String lastName;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -28,9 +34,18 @@ public class User {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
     }
     
     @Column(nullable = false)

--- a/backend/src/main/java/com/assettrack/dto/asset/AssetResponse.java
+++ b/backend/src/main/java/com/assettrack/dto/asset/AssetResponse.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AssetResponse {
-    private Long id;
+    private java.util.UUID id;
     private String type;
     private String brand;
     private String model;
@@ -22,4 +22,7 @@ public class AssetResponse {
     private LocalDate warrantyExpirationDate;
     private String status;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private boolean warrantyExpired;
+    private String currentOwner;
 }

--- a/backend/src/main/java/com/assettrack/dto/asset/ConditionReportResponse.java
+++ b/backend/src/main/java/com/assettrack/dto/asset/ConditionReportResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.assettrack.dto.user.UserResponse;
 
 import java.time.LocalDate;
 
@@ -12,11 +13,9 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ConditionReportResponse {
-    private Long id;
-    private Long assetId;
-    private String assetSerialNumber;
-    private Long reportedById;
-    private String reportedByEmail;
+    private java.util.UUID id;
+    private AssetResponse asset;
+    private UserResponse reportedBy;
     private String issueDescription;
     private LocalDate reportDate;
     private String status;

--- a/backend/src/main/java/com/assettrack/dto/asset/CreateConditionReportRequest.java
+++ b/backend/src/main/java/com/assettrack/dto/asset/CreateConditionReportRequest.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class CreateConditionReportRequest {
 
     @NotNull(message = "Asset ID is required")
-    private Long assetId;
+    private java.util.UUID assetId;
 
     @NotBlank(message = "Issue description is required")
     private String issueDescription;

--- a/backend/src/main/java/com/assettrack/dto/asset/ReportConditionRequest.java
+++ b/backend/src/main/java/com/assettrack/dto/asset/ReportConditionRequest.java
@@ -14,4 +14,7 @@ public class ReportConditionRequest {
 
     @NotBlank(message = "Issue description is required")
     private String issueDescription;
+
+    @NotBlank(message = "Severity is required")
+    private String severity;
 }

--- a/backend/src/main/java/com/assettrack/dto/auth/AuthResponse.java
+++ b/backend/src/main/java/com/assettrack/dto/auth/AuthResponse.java
@@ -3,10 +3,14 @@ package com.assettrack.dto.auth;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import com.assettrack.dto.user.UserResponse;
+
 @Data
 @AllArgsConstructor
 public class AuthResponse {
 
-    private String token;
-    private String role;
+    private String accessToken;
+    private String tokenType;
+    private long expiresIn;
+    private UserResponse user;
 }

--- a/backend/src/main/java/com/assettrack/dto/auth/SignupRequest.java
+++ b/backend/src/main/java/com/assettrack/dto/auth/SignupRequest.java
@@ -12,6 +12,9 @@ public class SignupRequest {
     @Email(message = "Email must be valid")
     private String email;
 
+    @NotBlank(message = "Full name is required")
+    private String fullName;
+
     @NotBlank(message = "Password is required")
     @Pattern(
             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{8,}$",

--- a/backend/src/main/java/com/assettrack/dto/dashboard/DashboardSummaryDto.java
+++ b/backend/src/main/java/com/assettrack/dto/dashboard/DashboardSummaryDto.java
@@ -11,14 +11,22 @@ import java.util.List;
 @AllArgsConstructor
 public class DashboardSummaryDto {
     private long totalAssets;
-    private ChartData statusDistribution;
-    private ChartData typeDistribution;
+    private List<StatusCountDto> byStatus;
+    private List<TypeCountDto> byType;
 
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ChartData {
-        private List<String> labels;
-        private List<Long> data;
+    public static class StatusCountDto {
+        private String status;
+        private long count;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TypeCountDto {
+        private String type;
+        private long count;
     }
 }

--- a/backend/src/main/java/com/assettrack/dto/dashboard/QuickSpareAssetDto.java
+++ b/backend/src/main/java/com/assettrack/dto/dashboard/QuickSpareAssetDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class QuickSpareAssetDto {
-    private Long id;
+    private java.util.UUID id;
     private String type;
     private String status;
 }

--- a/backend/src/main/java/com/assettrack/dto/notification/NotificationResponse.java
+++ b/backend/src/main/java/com/assettrack/dto/notification/NotificationResponse.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class NotificationResponse {
-    private Long id;
+    private java.util.UUID id;
     private String recipient;
     private String messageBody;
     private String type;

--- a/backend/src/main/java/com/assettrack/dto/user/UserResponse.java
+++ b/backend/src/main/java/com/assettrack/dto/user/UserResponse.java
@@ -1,18 +1,22 @@
 package com.assettrack.dto.user;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserResponse {
-    private long id;
+    private java.util.UUID id;
     private String email;
     private String role;
     private boolean isActive;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String fullName;
 }

--- a/backend/src/main/java/com/assettrack/mapper/asset/AssetMapper.java
+++ b/backend/src/main/java/com/assettrack/mapper/asset/AssetMapper.java
@@ -7,17 +7,18 @@ import com.assettrack.dto.asset.ConditionReportResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+import com.assettrack.mapper.user.UserMapper;
+
+@Mapper(componentModel = "spring", uses = {UserMapper.class})
 public interface AssetMapper {
 
     @Mapping(target = "type", expression = "java(asset.getType().name())")
     @Mapping(target = "status", expression = "java(asset.getStatus().name())")
+    @Mapping(target = "warrantyExpired", expression = "java(asset.getWarrantyExpirationDate() != null && asset.getWarrantyExpirationDate().isBefore(java.time.LocalDate.now()))")
     AssetResponse toResponse(Asset asset);
 
-    @Mapping(target = "assetId", source = "asset.id")
-    @Mapping(target = "assetSerialNumber", source = "asset.serialNumber")
-    @Mapping(target = "reportedById", source = "reportedBy.id")
-    @Mapping(target = "reportedByEmail", source = "reportedBy.email")
+    @Mapping(target = "asset", source = "asset")
+    @Mapping(target = "reportedBy", source = "reportedBy")
     @Mapping(target = "status", expression = "java(report.getStatus().name())")
     ConditionReportResponse toResponse(ConditionReport report);
 }

--- a/backend/src/main/java/com/assettrack/mapper/auth/AuthMapper.java
+++ b/backend/src/main/java/com/assettrack/mapper/auth/AuthMapper.java
@@ -4,9 +4,15 @@ import com.assettrack.domain.user.User;
 import com.assettrack.dto.auth.AuthResponse;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
-public interface AuthMapper {
-    default AuthResponse toResponse(String token, User user) {
-        return new AuthResponse(token, user.getRole().name());
+import com.assettrack.mapper.user.UserMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Mapper(componentModel = "spring", uses = {UserMapper.class})
+public abstract class AuthMapper {
+    @Autowired
+    protected UserMapper userMapper;
+
+    public AuthResponse toResponse(String token, User user) {
+        return new AuthResponse(token, "Bearer", 86400, userMapper.toResponse(user));
     }
 }

--- a/backend/src/main/java/com/assettrack/mapper/user/UserMapper.java
+++ b/backend/src/main/java/com/assettrack/mapper/user/UserMapper.java
@@ -8,5 +8,6 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface UserMapper {
     @Mapping(target = "role", expression = "java(user.getRole().name())")
+    @Mapping(target = "fullName", expression = "java(user.getFirstName() != null || user.getLastName() != null ? (user.getFirstName() != null ? user.getFirstName() + \" \" : \"\") + (user.getLastName() != null ? user.getLastName() : \"\").trim() : null)")
     UserResponse toResponse(User user);
 }

--- a/backend/src/main/java/com/assettrack/repository/asset/AssetAllocationRepository.java
+++ b/backend/src/main/java/com/assettrack/repository/asset/AssetAllocationRepository.java
@@ -7,9 +7,9 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface AssetAllocationRepository extends JpaRepository<AssetAllocation, Long> {
+public interface AssetAllocationRepository extends JpaRepository<AssetAllocation, java.util.UUID> {
 
-    List<AssetAllocation> findByAssetIdOrderByCheckoutDateDesc(Long assetId);
+    List<AssetAllocation> findByAssetIdOrderByCheckoutDateDesc(java.util.UUID assetId);
 
-    boolean existsByAssetIdAndUserIdAndReturnDateIsNull(Long assetId, Long userId);
+    boolean existsByAssetIdAndUserIdAndReturnDateIsNull(java.util.UUID assetId, java.util.UUID userId);
 }

--- a/backend/src/main/java/com/assettrack/repository/asset/AssetRepository.java
+++ b/backend/src/main/java/com/assettrack/repository/asset/AssetRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface AssetRepository extends JpaRepository<Asset, Long>, JpaSpecificationExecutor<Asset> {
+public interface AssetRepository extends JpaRepository<Asset, java.util.UUID>, JpaSpecificationExecutor<Asset> {
 
     Optional<Asset> findBySerialNumber(String serialNumber);
 

--- a/backend/src/main/java/com/assettrack/repository/asset/ConditionReportRepository.java
+++ b/backend/src/main/java/com/assettrack/repository/asset/ConditionReportRepository.java
@@ -8,15 +8,15 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ConditionReportRepository extends JpaRepository<ConditionReport, Long> {
+public interface ConditionReportRepository extends JpaRepository<ConditionReport, java.util.UUID> {
 
     List<ConditionReport> findAllByOrderByReportDateDesc();
 
-    List<ConditionReport> findByAssetIdOrderByReportDateDesc(Long assetId);
+    List<ConditionReport> findByAssetIdOrderByReportDateDesc(java.util.UUID assetId);
 
-    List<ConditionReport> findByAssetIdAndReportedByIdOrderByReportDateDesc(Long assetId, Long userId);
+    List<ConditionReport> findByAssetIdAndReportedByIdOrderByReportDateDesc(java.util.UUID assetId, java.util.UUID userId);
 
-    List<ConditionReport> findByReportedByIdOrderByReportDateDesc(Long userId);
+    List<ConditionReport> findByReportedByIdOrderByReportDateDesc(java.util.UUID userId);
 
     List<ConditionReport> findByStatus(ReportStatus status);
 }

--- a/backend/src/main/java/com/assettrack/repository/notification/NotificationRepository.java
+++ b/backend/src/main/java/com/assettrack/repository/notification/NotificationRepository.java
@@ -8,9 +8,9 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
+public interface NotificationRepository extends JpaRepository<Notification, java.util.UUID> {
 
     List<Notification> findByRecipientOrderByCreatedAtDesc(String recipient);
 
-    Optional<Notification> findByIdAndRecipient(Long id, String recipient);
+    Optional<Notification> findByIdAndRecipient(java.util.UUID id, String recipient);
 }

--- a/backend/src/main/java/com/assettrack/repository/user/UserRepository.java
+++ b/backend/src/main/java/com/assettrack/repository/user/UserRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, java.util.UUID> {
 
     Optional<User> findByEmail(String email);
 

--- a/backend/src/main/java/com/assettrack/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/assettrack/security/config/SecurityConfig.java
@@ -22,16 +22,16 @@ public class SecurityConfig {
         return http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .authorizeHttpRequests(auth -> auth
+                        // Self-service user endpoints accessible to any authenticated user
+                        .requestMatchers("/auth/me", "/auth/me/**").authenticated()
+
                         // Public endpoints
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/auth/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/actuator/health").permitAll()
 
-                        // Self-service user endpoints accessible to any authenticated user
-                        .requestMatchers("/api/users/me", "/api/users/me/**").authenticated()
-
                         // Admin-only user management endpoints
-                        .requestMatchers("/api/users/**").hasRole("ADMIN")
+                        .requestMatchers("/users/**").hasRole("ADMIN")
 
                         // All other endpoints (Assets, Allocation, Reports) require a valid JWT
                         .anyRequest().authenticated()

--- a/backend/src/main/java/com/assettrack/security/util/SecurityUtils.java
+++ b/backend/src/main/java/com/assettrack/security/util/SecurityUtils.java
@@ -19,17 +19,17 @@ public class SecurityUtils {
      * Extract current user ID from JWT authentication.
      * Handles both Long and String representations of userId in the JWT claim.
      */
-    public Long getCurrentUserId(Authentication authentication) {
+    public java.util.UUID getCurrentUserId(Authentication authentication) {
         if (authentication instanceof JwtAuthenticationToken jwtAuth) {
             Jwt jwt = jwtAuth.getToken();
             Object userIdClaim = jwt.getClaim("userId");
-            if (userIdClaim instanceof Number number) {
-                return number.longValue();
+            if (userIdClaim instanceof java.util.UUID uuid) {
+                return uuid;
             }
             if (userIdClaim instanceof String userIdStr) {
                 try {
-                    return Long.parseLong(userIdStr);
-                } catch (NumberFormatException e) {
+                    return java.util.UUID.fromString(userIdStr);
+                } catch (IllegalArgumentException e) {
                     throw new RuntimeException("Invalid user ID in token: " + userIdStr);
                 }
             }

--- a/backend/src/main/java/com/assettrack/service/asset/AssetService.java
+++ b/backend/src/main/java/com/assettrack/service/asset/AssetService.java
@@ -86,10 +86,10 @@ public class AssetService {
      * Managers and admins can report on any asset; regular users must currently own it.
      */
     @Transactional
-    public ConditionReportResponse createConditionReport(Long assetId,
+    public ConditionReportResponse createConditionReport(java.util.UUID assetId,
                                                           String issueDescription,
                                                           Authentication authentication) {
-        Long userId = securityUtils.getCurrentUserId(authentication);
+        java.util.UUID userId = securityUtils.getCurrentUserId(authentication);
 
         Asset asset = assetRepository.findById(assetId)
                 .orElseThrow(() -> new ResourceNotFoundException(
@@ -117,7 +117,7 @@ public class AssetService {
      */
     @Transactional(readOnly = true)
     public List<ConditionReportResponse> getConditionReports(Authentication authentication) {
-        Long userId = securityUtils.getCurrentUserId(authentication);
+        java.util.UUID userId = securityUtils.getCurrentUserId(authentication);
         List<ConditionReport> reports = securityUtils.isManagerOrAdmin(authentication)
                 ? conditionReportRepository.findAllByOrderByReportDateDesc()
                 : conditionReportRepository.findByReportedByIdOrderByReportDateDesc(userId);
@@ -131,13 +131,13 @@ public class AssetService {
      * Returns all condition reports for a specific asset, newest first.
      */
     @Transactional(readOnly = true)
-    public List<ConditionReportResponse> getReportsByAsset(Long assetId,
+    public List<ConditionReportResponse> getReportsByAsset(java.util.UUID assetId,
                                                             Authentication authentication) {
         if (!assetRepository.existsById(assetId)) {
             throw new ResourceNotFoundException("Asset not found with id: " + assetId);
         }
 
-        Long userId = securityUtils.getCurrentUserId(authentication);
+        java.util.UUID userId = securityUtils.getCurrentUserId(authentication);
         List<ConditionReport> reports = securityUtils.isManagerOrAdmin(authentication)
                 ? conditionReportRepository.findByAssetIdOrderByReportDateDesc(assetId)
                 : conditionReportRepository.findByAssetIdAndReportedByIdOrderByReportDateDesc(assetId, userId);
@@ -152,7 +152,7 @@ public class AssetService {
      * Returns a single condition report by ID.
      */
     @Transactional(readOnly = true)
-    public ConditionReportResponse getReportById(Long reportId,
+    public ConditionReportResponse getReportById(java.util.UUID reportId,
                                                   Authentication authentication) {
         ConditionReport report = conditionReportRepository.findById(reportId)
                 .orElseThrow(() -> new ResourceNotFoundException(
@@ -165,7 +165,7 @@ public class AssetService {
      * Resolves an open condition report.
      */
     @Transactional
-    public ConditionReportResponse resolveReport(Long reportId) {
+    public ConditionReportResponse resolveReport(java.util.UUID reportId) {
         ConditionReport report = conditionReportRepository.findById(reportId)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Condition report not found with id: " + reportId));
@@ -173,7 +173,7 @@ public class AssetService {
         return assetMapper.toResponse(conditionReportRepository.save(report));
     }
 
-    private void ensureCanSubmitConditionReport(Long assetId, Long userId, Authentication authentication) {
+    private void ensureCanSubmitConditionReport(java.util.UUID assetId, java.util.UUID userId, Authentication authentication) {
         if (securityUtils.isManagerOrAdmin(authentication)) {
             return;
         }
@@ -189,7 +189,7 @@ public class AssetService {
             return;
         }
 
-        Long userId = securityUtils.getCurrentUserId(authentication);
+        java.util.UUID userId = securityUtils.getCurrentUserId(authentication);
         if (!report.getReportedBy().getId().equals(userId)) {
             throw new SelfOperationException("You can only view your own condition reports");
         }

--- a/backend/src/main/java/com/assettrack/service/dashboard/DashboardService.java
+++ b/backend/src/main/java/com/assettrack/service/dashboard/DashboardService.java
@@ -26,27 +26,21 @@ public class DashboardService {
         Map<AssetStatus, Long> statusCounts = assetRepository.countByStatus().stream()
                 .collect(Collectors.toMap(AssetRepository.StatusCount::getStatus, AssetRepository.StatusCount::getCount));
 
-        List<String> statusLabels = Arrays.stream(AssetStatus.values())
-                .map(Enum::name)
-                .collect(Collectors.toList());
-        List<Long> statusData = Arrays.stream(AssetStatus.values())
-                .map(s -> statusCounts.getOrDefault(s, 0L))
+        List<DashboardSummaryDto.StatusCountDto> byStatus = Arrays.stream(AssetStatus.values())
+                .map(s -> new DashboardSummaryDto.StatusCountDto(s.name(), statusCounts.getOrDefault(s, 0L)))
                 .collect(Collectors.toList());
 
         Map<AssetType, Long> typeCounts = assetRepository.countByType().stream()
                 .collect(Collectors.toMap(AssetRepository.TypeCount::getType, AssetRepository.TypeCount::getCount));
 
-        List<String> typeLabels = Arrays.stream(AssetType.values())
-                .map(Enum::name)
-                .collect(Collectors.toList());
-        List<Long> typeData = Arrays.stream(AssetType.values())
-                .map(t -> typeCounts.getOrDefault(t, 0L))
+        List<DashboardSummaryDto.TypeCountDto> byType = Arrays.stream(AssetType.values())
+                .map(t -> new DashboardSummaryDto.TypeCountDto(t.name(), typeCounts.getOrDefault(t, 0L)))
                 .collect(Collectors.toList());
 
         return new DashboardSummaryDto(
                 totalAssets,
-                new DashboardSummaryDto.ChartData(statusLabels, statusData),
-                new DashboardSummaryDto.ChartData(typeLabels, typeData)
+                byStatus,
+                byType
         );
     }
 

--- a/backend/src/main/java/com/assettrack/service/notification/NotificationService.java
+++ b/backend/src/main/java/com/assettrack/service/notification/NotificationService.java
@@ -32,7 +32,7 @@ public class NotificationService {
     }
 
     @Transactional
-    public NotificationResponse markAsRead(Long notificationId, Authentication authentication) {
+    public NotificationResponse markAsRead(java.util.UUID notificationId, Authentication authentication) {
         String recipient = getCurrentUserEmail(authentication);
         Notification notification = notificationRepository.findByIdAndRecipient(notificationId, recipient)
                 .orElseThrow(() -> new ResourceNotFoundException(
@@ -43,7 +43,7 @@ public class NotificationService {
     }
 
     private String getCurrentUserEmail(Authentication authentication) {
-        Long userId = securityUtils.getCurrentUserId(authentication);
+        java.util.UUID userId = securityUtils.getCurrentUserId(authentication);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
         return user.getEmail();

--- a/backend/src/main/java/com/assettrack/service/user/UserService.java
+++ b/backend/src/main/java/com/assettrack/service/user/UserService.java
@@ -33,7 +33,7 @@ public class UserService {
      * @throws ResourceNotFoundException if the authenticated user no longer exists
      */
     public UserResponse getMyProfile(Authentication authentication) {
-        long currentId = securityUtils.getCurrentUserId(authentication);
+        java.util.UUID currentId = securityUtils.getCurrentUserId(authentication);
         User user = userRepository.findById(currentId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + currentId));
         return userMapper.toResponse(user);
@@ -69,7 +69,7 @@ public class UserService {
      * @return the {@link UserResponse} DTO
      * @throws ResourceNotFoundException if no user exists with the given ID
      */
-    public UserResponse getUserById(Long id){
+    public UserResponse getUserById(java.util.UUID id){
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + id));
         return userMapper.toResponse(user);
@@ -87,7 +87,7 @@ public class UserService {
      * @throws EmailAlreadyExistsException if the new email is already in use
      */
     public UserResponse updateEmail(UpdateEmailRequest request, Authentication authentication){
-        long currentId = securityUtils.getCurrentUserId(authentication);
+        java.util.UUID currentId = securityUtils.getCurrentUserId(authentication);
         User user =  userRepository.findById(currentId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + currentId));
         if(!passwordEncoder.matches(request.getPassword(),user.getPasswordHash())){
@@ -112,7 +112,7 @@ public class UserService {
      * @throws InvalidPasswordException if the current password does not match
      */
     public void updatePassword(UpdatePasswordRequest request, Authentication authentication){
-        long currentId = securityUtils.getCurrentUserId(authentication);
+        java.util.UUID currentId = securityUtils.getCurrentUserId(authentication);
         User user =  userRepository.findById(currentId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + currentId));
         if(!passwordEncoder.matches(request.getCurrentPassword(),user.getPasswordHash())){
@@ -134,11 +134,11 @@ public class UserService {
      * @throws InvalidRoleException if the provided role string is not a valid {@link Role}
      * @throws SelfOperationException if the admin attempts to change their own role
      */
-    public UserResponse updateUserRole(Long id, String role, Authentication authentication){
+    public UserResponse updateUserRole(java.util.UUID id, String role, Authentication authentication){
 
         User user =  userRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + id));
-        long currentId = securityUtils.getCurrentUserId(authentication);
+        java.util.UUID currentId = securityUtils.getCurrentUserId(authentication);
         Role roleEnum;
         try {
             roleEnum = Role.valueOf(role.toUpperCase());
@@ -165,10 +165,10 @@ public class UserService {
      * @throws ResourceNotFoundException if no user exists with the given ID
      * @throws SelfOperationException if the admin attempts to change their own status
      */
-    public UserResponse updateUserStatus(Long id, boolean active, Authentication authentication){
+    public UserResponse updateUserStatus(java.util.UUID id, boolean active, Authentication authentication){
         User user =  userRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + id));
-        long currentId = securityUtils.getCurrentUserId(authentication);
+        java.util.UUID currentId = securityUtils.getCurrentUserId(authentication);
         if (id.equals(currentId)) {
             throw new SelfOperationException("Admin cannot change their own status");
         }
@@ -186,7 +186,7 @@ public class UserService {
      * @throws ResourceNotFoundException if the authenticated user no longer exists
      */
     public void deleteSelf(Authentication authentication){
-        long currentId = securityUtils.getCurrentUserId(authentication);
+        java.util.UUID currentId = securityUtils.getCurrentUserId(authentication);
         User user =  userRepository.findById(currentId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + currentId));
         user.setActive(false);
@@ -204,10 +204,10 @@ public class UserService {
      * @throws SelfOperationException if the admin attempts to delete their own account
      * @throws ActiveUserDeletionException if the target user is still active
      */
-    public void deleteUser(Long id, Authentication authentication){
+    public void deleteUser(java.util.UUID id, Authentication authentication){
         User user =  userRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + id));
-        long currentId = securityUtils.getCurrentUserId(authentication);
+        java.util.UUID currentId = securityUtils.getCurrentUserId(authentication);
         if (id.equals(currentId)) {
             throw new SelfOperationException("Admin cannot delete their own account");
         }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+server:
+  servlet:
+    context-path: /api/v1
+
 spring:
   application:
     name: AssetTrack
@@ -7,7 +11,7 @@ spring:
     password: password
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
   config:
     import: "optional:file:.env[.properties]"

--- a/backend/src/test/java/com/assettrack/controller/ConditionAndNotificationControllerIntegrationTest.java
+++ b/backend/src/test/java/com/assettrack/controller/ConditionAndNotificationControllerIntegrationTest.java
@@ -100,13 +100,14 @@ class ConditionAndNotificationControllerIntegrationTest {
                 .checkoutDate(LocalDateTime.now())
                 .build());
 
-        mockMvc.perform(post("/api/assets/{id}/condition", unownedAsset.getId())
+        mockMvc.perform(post("/api/v1/assets/{id}/condition", unownedAsset.getId())
+                        .contextPath("/api/v1")
                         .with(jwt().jwt(token -> token
                                         .claim("userId", currentUser.getId())
                                         .claim("role", "ROLE_DEVELOPER"))
                                 .authorities(new SimpleGrantedAuthority("ROLE_DEVELOPER")))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"issueDescription\":\"Screen flickers intermittently\"}"))
+                        .content("{\"issueDescription\":\"Screen flickers intermittently\", \"severity\":\"MEDIUM\"}"))
                 .andExpect(status().isForbidden());
     }
 
@@ -128,7 +129,8 @@ class ConditionAndNotificationControllerIntegrationTest {
                 .createdAt(LocalDateTime.now())
                 .build());
 
-        mockMvc.perform(get("/api/notifications")
+        mockMvc.perform(get("/api/v1/notifications")
+                        .contextPath("/api/v1")
                         .with(jwt().jwt(token -> token
                                         .claim("userId", currentUser.getId())
                                         .claim("role", "ROLE_DEVELOPER"))
@@ -157,13 +159,14 @@ class ConditionAndNotificationControllerIntegrationTest {
                 .createdAt(LocalDateTime.now())
                 .build());
 
-        mockMvc.perform(patch("/api/notifications/{notificationId}/read", ownNotification.getId())
+        mockMvc.perform(patch("/api/v1/notifications/{notificationId}/read", ownNotification.getId())
+                        .contextPath("/api/v1")
                         .with(jwt().jwt(token -> token
                                         .claim("userId", currentUser.getId())
                                         .claim("role", "ROLE_DEVELOPER"))
                                 .authorities(new SimpleGrantedAuthority("ROLE_DEVELOPER"))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(ownNotification.getId()))
+                .andExpect(jsonPath("$.id").value(ownNotification.getId().toString()))
                 .andExpect(jsonPath("$.recipient").value(currentUser.getEmail()))
                 .andExpect(jsonPath("$.read").value(true));
 
@@ -185,7 +188,8 @@ class ConditionAndNotificationControllerIntegrationTest {
                 .createdAt(LocalDateTime.now())
                 .build());
 
-        mockMvc.perform(patch("/api/notifications/{notificationId}/read", otherNotification.getId())
+        mockMvc.perform(patch("/api/v1/notifications/{notificationId}/read", otherNotification.getId())
+                        .contextPath("/api/v1")
                         .with(jwt().jwt(token -> token
                                         .claim("userId", currentUser.getId())
                                         .claim("role", "ROLE_DEVELOPER"))

--- a/backend/src/test/java/com/assettrack/security/DummyTestController.java
+++ b/backend/src/test/java/com/assettrack/security/DummyTestController.java
@@ -6,12 +6,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class DummyTestController {
 
-    @GetMapping("/api/auth/test")
+    @GetMapping("/auth/test")
     public String publicEndpoint() { return "Public OK"; }
     
-    @GetMapping("/api/assets/test")
+    @GetMapping("/assets/test")
     public String protectedEndpoint() { return "Protected OK"; }
     
-    @GetMapping("/api/users/test")
+    @GetMapping("/users/test")
     public String adminEndpoint() { return "Admin OK"; }
 }

--- a/backend/src/test/java/com/assettrack/security/SecurityFilterChainTest.java
+++ b/backend/src/test/java/com/assettrack/security/SecurityFilterChainTest.java
@@ -1,5 +1,6 @@
 package com.assettrack.security;
 
+import java.util.UUID;
 import com.assettrack.repository.user.UserRepository;
 import com.assettrack.service.asset.AssetService;
 import com.assettrack.service.auth.AuthService;
@@ -112,26 +113,26 @@ public class SecurityFilterChainTest {
 
     @Test
     public void publicEndpoint_ShouldReturn200() throws Exception {
-        mockMvc.perform(get("/api/auth/test"))
+        mockMvc.perform(get("/api/v1/auth/test").contextPath("/api/v1"))
                 .andExpect(status().isOk());
     }
 
     @Test
     public void protectedEndpoint_WithoutJwt_ShouldReturn401() throws Exception {
-        mockMvc.perform(get("/api/assets/test"))
+        mockMvc.perform(get("/api/v1/assets/test").contextPath("/api/v1"))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     public void adminEndpoint_WithDeveloperRole_ShouldReturn403() throws Exception {
-        mockMvc.perform(get("/api/users/test")
+        mockMvc.perform(get("/api/v1/users/test").contextPath("/api/v1")
                 .with(jwt().jwt(jwt -> jwt.claim("role", "DEVELOPER"))))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     public void adminEndpoint_WithAdminRole_ShouldReturn200() throws Exception {
-        mockMvc.perform(get("/api/users/test")
+        mockMvc.perform(get("/api/v1/users/test").contextPath("/api/v1")
                 .with(jwt().jwt(jwt -> jwt.claim("role", "ADMIN"))
                         .authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
                 .andExpect(status().isOk());
@@ -139,7 +140,7 @@ public class SecurityFilterChainTest {
 
     @Test
     public void usersEndpoint_WithManagerRole_ShouldReturn403() throws Exception {
-        mockMvc.perform(get("/api/users")
+        mockMvc.perform(get("/api/v1/users").contextPath("/api/v1")
                 .with(jwt().jwt(jwt -> jwt.claim("role", "MANAGER"))
                         .authorities(new SimpleGrantedAuthority("ROLE_MANAGER"))))
                 .andExpect(status().isForbidden());
@@ -147,7 +148,7 @@ public class SecurityFilterChainTest {
 
     @Test
     public void usersEndpoint_WithAdminRole_ShouldReturn200() throws Exception {
-        mockMvc.perform(get("/api/users")
+        mockMvc.perform(get("/api/v1/users").contextPath("/api/v1")
                 .with(jwt().jwt(jwt -> jwt.claim("role", "ADMIN"))
                         .authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
                 .andExpect(status().isOk());
@@ -155,15 +156,15 @@ public class SecurityFilterChainTest {
 
     @Test
     public void selfProfileEndpoint_WithAuthenticatedUser_ShouldReturn200() throws Exception {
-        mockMvc.perform(get("/api/users/me")
-                .with(jwt().jwt(jwt -> jwt.claim("role", "DEVELOPER").claim("userId", 1L))
+        mockMvc.perform(get("/api/v1/auth/me").contextPath("/api/v1")
+                .with(jwt().jwt(jwt -> jwt.claim("role", "DEVELOPER").claim("userId", UUID.fromString("00000000-0000-0000-0000-000000000001")))
                         .authorities(new SimpleGrantedAuthority("ROLE_DEVELOPER"))))
                 .andExpect(status().isOk());
     }
 
     @Test
     public void selfProfileEndpoint_WithoutJwt_ShouldReturn401() throws Exception {
-        mockMvc.perform(get("/api/users/me"))
+        mockMvc.perform(get("/api/v1/auth/me").contextPath("/api/v1"))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/backend/src/test/java/com/assettrack/service/asset/AssetServiceTest.java
+++ b/backend/src/test/java/com/assettrack/service/asset/AssetServiceTest.java
@@ -1,5 +1,6 @@
 package com.assettrack.service.asset;
 
+import java.util.UUID;
 import com.assettrack.domain.asset.Asset;
 import com.assettrack.domain.asset.AssetStatus;
 import com.assettrack.domain.asset.AssetType;
@@ -87,9 +88,9 @@ class AssetServiceTest {
         Asset asset = testAsset();
         User reporter = testUser();
         ConditionReportResponse mappedResponse = ConditionReportResponse.builder()
-                .id(10L)
-                .assetId(asset.getId())
-                .reportedById(reporter.getId())
+                .id(UUID.fromString("00000000-0000-0000-0000-000000000010"))
+                .asset(com.assettrack.dto.asset.AssetResponse.builder().id(asset.getId()).build())
+                .reportedBy(com.assettrack.dto.user.UserResponse.builder().id(reporter.getId()).build())
                 .issueDescription("Battery no longer charges")
                 .status("OPEN")
                 .build();
@@ -120,10 +121,10 @@ class AssetServiceTest {
 
     @Test
     void getConditionReports_WhenManagerOrAdmin_ReturnsAllReports() {
-        ConditionReport report = testReport(1L, testUser(7L));
-        ConditionReportResponse mapped = ConditionReportResponse.builder().id(1L).build();
+        ConditionReport report = testReport(UUID.fromString("00000000-0000-0000-0000-000000000001"), testUser(UUID.fromString("00000000-0000-0000-0000-000000000007")));
+        ConditionReportResponse mapped = ConditionReportResponse.builder().id(UUID.fromString("00000000-0000-0000-0000-000000000001")).build();
 
-        when(securityUtils.getCurrentUserId(authentication)).thenReturn(7L);
+        when(securityUtils.getCurrentUserId(authentication)).thenReturn(UUID.fromString("00000000-0000-0000-0000-000000000007"));
         when(securityUtils.isManagerOrAdmin(authentication)).thenReturn(true);
         when(conditionReportRepository.findAllByOrderByReportDateDesc()).thenReturn(List.of(report));
         when(assetMapper.toResponse(report)).thenReturn(mapped);
@@ -137,29 +138,29 @@ class AssetServiceTest {
 
     @Test
     void getConditionReports_WhenRegularUser_ReturnsOnlyOwnReports() {
-        ConditionReport ownReport = testReport(1L, testUser(7L));
-        ConditionReportResponse mapped = ConditionReportResponse.builder().id(1L).build();
+        ConditionReport ownReport = testReport(UUID.fromString("00000000-0000-0000-0000-000000000001"), testUser(UUID.fromString("00000000-0000-0000-0000-000000000007")));
+        ConditionReportResponse mapped = ConditionReportResponse.builder().id(UUID.fromString("00000000-0000-0000-0000-000000000001")).build();
 
-        when(securityUtils.getCurrentUserId(authentication)).thenReturn(7L);
+        when(securityUtils.getCurrentUserId(authentication)).thenReturn(UUID.fromString("00000000-0000-0000-0000-000000000007"));
         when(securityUtils.isManagerOrAdmin(authentication)).thenReturn(false);
-        when(conditionReportRepository.findByReportedByIdOrderByReportDateDesc(7L)).thenReturn(List.of(ownReport));
+        when(conditionReportRepository.findByReportedByIdOrderByReportDateDesc(UUID.fromString("00000000-0000-0000-0000-000000000007"))).thenReturn(List.of(ownReport));
         when(assetMapper.toResponse(ownReport)).thenReturn(mapped);
 
         List<ConditionReportResponse> result = assetService.getConditionReports(authentication);
 
         assertThat(result).containsExactly(mapped);
-        verify(conditionReportRepository).findByReportedByIdOrderByReportDateDesc(7L);
+        verify(conditionReportRepository).findByReportedByIdOrderByReportDateDesc(UUID.fromString("00000000-0000-0000-0000-000000000007"));
         verify(conditionReportRepository, never()).findAllByOrderByReportDateDesc();
     }
 
     @Test
     void getReportsByAsset_WhenManagerOrAdmin_ReturnsAllAssetReports() {
-        Long assetId = 99L;
-        ConditionReport report = testReport(1L, testUser(8L));
-        ConditionReportResponse mapped = ConditionReportResponse.builder().id(1L).assetId(assetId).build();
+        UUID assetId = UUID.fromString("00000000-0000-0000-0000-000000000099");
+        ConditionReport report = testReport(UUID.fromString("00000000-0000-0000-0000-000000000001"), testUser(UUID.fromString("00000000-0000-0000-0000-000000000008")));
+        ConditionReportResponse mapped = ConditionReportResponse.builder().id(UUID.fromString("00000000-0000-0000-0000-000000000001")).asset(com.assettrack.dto.asset.AssetResponse.builder().id(assetId).build()).build();
 
         when(assetRepository.existsById(assetId)).thenReturn(true);
-        when(securityUtils.getCurrentUserId(authentication)).thenReturn(7L);
+        when(securityUtils.getCurrentUserId(authentication)).thenReturn(UUID.fromString("00000000-0000-0000-0000-000000000007"));
         when(securityUtils.isManagerOrAdmin(authentication)).thenReturn(true);
         when(conditionReportRepository.findByAssetIdOrderByReportDateDesc(assetId)).thenReturn(List.of(report));
         when(assetMapper.toResponse(report)).thenReturn(mapped);
@@ -174,10 +175,10 @@ class AssetServiceTest {
 
     @Test
     void getReportsByAsset_WhenRegularUser_ReturnsOnlyOwnAssetReports() {
-        Long assetId = 99L;
-        Long userId = 7L;
-        ConditionReport ownReport = testReport(1L, testUser(userId));
-        ConditionReportResponse mapped = ConditionReportResponse.builder().id(1L).assetId(assetId).build();
+        UUID assetId = UUID.fromString("00000000-0000-0000-0000-000000000099");
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000007");
+        ConditionReport ownReport = testReport(UUID.fromString("00000000-0000-0000-0000-000000000001"), testUser(userId));
+        ConditionReportResponse mapped = ConditionReportResponse.builder().id(UUID.fromString("00000000-0000-0000-0000-000000000001")).asset(com.assettrack.dto.asset.AssetResponse.builder().id(assetId).build()).build();
 
         when(assetRepository.existsById(assetId)).thenReturn(true);
         when(securityUtils.getCurrentUserId(authentication)).thenReturn(userId);
@@ -195,8 +196,8 @@ class AssetServiceTest {
 
     @Test
     void getReportById_WhenManagerOrAdmin_CanViewAnyReport() {
-        Long reportId = 44L;
-        ConditionReport report = testReport(reportId, testUser(99L));
+        UUID reportId = UUID.fromString("00000000-0000-0000-0000-000000000044");
+        ConditionReport report = testReport(reportId, testUser(UUID.fromString("00000000-0000-0000-0000-000000000099")));
         ConditionReportResponse mapped = ConditionReportResponse.builder().id(reportId).build();
 
         when(conditionReportRepository.findById(reportId)).thenReturn(Optional.of(report));
@@ -211,10 +212,10 @@ class AssetServiceTest {
 
     @Test
     void getReportById_WhenRegularUserViewsOwnReport_ReturnsReport() {
-        Long userId = 7L;
-        Long reportId = 45L;
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000007");
+        UUID reportId = UUID.fromString("00000000-0000-0000-0000-000000000045");
         ConditionReport ownReport = testReport(reportId, testUser(userId));
-        ConditionReportResponse mapped = ConditionReportResponse.builder().id(reportId).reportedById(userId).build();
+        ConditionReportResponse mapped = ConditionReportResponse.builder().id(reportId).reportedBy(com.assettrack.dto.user.UserResponse.builder().id(userId).build()).build();
 
         when(conditionReportRepository.findById(reportId)).thenReturn(Optional.of(ownReport));
         when(securityUtils.isManagerOrAdmin(authentication)).thenReturn(false);
@@ -228,9 +229,9 @@ class AssetServiceTest {
 
     @Test
     void getReportById_WhenRegularUserViewsAnotherUsersReport_ThrowsForbidden() {
-        Long userId = 7L;
-        Long reportId = 46L;
-        ConditionReport othersReport = testReport(reportId, testUser(8L));
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000007");
+        UUID reportId = UUID.fromString("00000000-0000-0000-0000-000000000046");
+        ConditionReport othersReport = testReport(reportId, testUser(UUID.fromString("00000000-0000-0000-0000-000000000008")));
 
         when(conditionReportRepository.findById(reportId)).thenReturn(Optional.of(othersReport));
         when(securityUtils.isManagerOrAdmin(authentication)).thenReturn(false);
@@ -245,7 +246,7 @@ class AssetServiceTest {
 
     private Asset testAsset() {
         return Asset.builder()
-                .id(99L)
+                .id(UUID.fromString("00000000-0000-0000-0000-000000000099"))
                 .type(AssetType.LAPTOP)
                 .brand("Dell")
                 .model("Latitude")
@@ -254,7 +255,7 @@ class AssetServiceTest {
                 .build();
     }
 
-    private ConditionReport testReport(Long reportId, User reporter) {
+    private ConditionReport testReport(UUID reportId, User reporter) {
         return ConditionReport.builder()
                 .id(reportId)
                 .asset(testAsset())
@@ -264,7 +265,7 @@ class AssetServiceTest {
                 .build();
     }
 
-    private User testUser(Long id) {
+    private User testUser(UUID id) {
         User user = testUser();
         user.setId(id);
         return user;
@@ -272,7 +273,7 @@ class AssetServiceTest {
 
     private User testUser() {
         return User.builder()
-                .id(7L)
+                .id(UUID.fromString("00000000-0000-0000-0000-000000000007"))
                 .email("developer@assettrack.com")
                 .passwordHash("$2a$12$hashed_password")
                 .role(Role.DEVELOPER)

--- a/backend/src/test/java/com/assettrack/service/dashboard/DashboardIntegrationTest.java
+++ b/backend/src/test/java/com/assettrack/service/dashboard/DashboardIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.assettrack.service.dashboard;
 
+import java.util.UUID;
 import com.assettrack.domain.asset.Asset;
 import com.assettrack.domain.asset.AssetStatus;
 import com.assettrack.domain.asset.AssetType;
@@ -99,15 +100,15 @@ public class DashboardIntegrationTest {
 
         assertThat(summary.getTotalAssets()).isEqualTo(3L);
 
-        List<String> statusLabels = summary.getStatusDistribution().getLabels();
-        List<Long> statusData = summary.getStatusDistribution().getData();
+        List<String> statusLabels = summary.getByStatus().stream().map(DashboardSummaryDto.StatusCountDto::getStatus).toList();
+        List<Long> statusData = summary.getByStatus().stream().map(DashboardSummaryDto.StatusCountDto::getCount).toList();
         assertThat(statusLabels).containsExactly("AVAILABLE", "ALLOCATED", "EXPIRED");
         assertThat(statusData.get(statusLabels.indexOf("AVAILABLE"))).isEqualTo(2L);
         assertThat(statusData.get(statusLabels.indexOf("ALLOCATED"))).isEqualTo(1L);
         assertThat(statusData.get(statusLabels.indexOf("EXPIRED"))).isEqualTo(0L);
 
-        List<String> typeLabels = summary.getTypeDistribution().getLabels();
-        List<Long> typeData = summary.getTypeDistribution().getData();
+        List<String> typeLabels = summary.getByType().stream().map(DashboardSummaryDto.TypeCountDto::getType).toList();
+        List<Long> typeData = summary.getByType().stream().map(DashboardSummaryDto.TypeCountDto::getCount).toList();
         assertThat(typeLabels).containsExactly("LAPTOP", "SCREEN", "ACCESSORY");
         assertThat(typeData.get(typeLabels.indexOf("LAPTOP"))).isEqualTo(2L);
         assertThat(typeData.get(typeLabels.indexOf("SCREEN"))).isEqualTo(1L);

--- a/backend/src/test/java/com/assettrack/service/dashboard/DashboardServiceTest.java
+++ b/backend/src/test/java/com/assettrack/service/dashboard/DashboardServiceTest.java
@@ -1,5 +1,6 @@
 package com.assettrack.service.dashboard;
 
+import java.util.UUID;
 import com.assettrack.domain.asset.Asset;
 import com.assettrack.domain.asset.AssetStatus;
 import com.assettrack.domain.asset.AssetType;
@@ -57,15 +58,15 @@ class DashboardServiceTest {
 
         assertThat(summary.getTotalAssets()).isEqualTo(10L);
 
-        List<String> statusLabels = summary.getStatusDistribution().getLabels();
-        List<Long> statusData = summary.getStatusDistribution().getData();
+        List<String> statusLabels = summary.getByStatus().stream().map(DashboardSummaryDto.StatusCountDto::getStatus).toList();
+        List<Long> statusData = summary.getByStatus().stream().map(DashboardSummaryDto.StatusCountDto::getCount).toList();
         assertThat(statusLabels).containsExactly("AVAILABLE", "ALLOCATED", "EXPIRED");
         assertThat(statusData.get(statusLabels.indexOf("AVAILABLE"))).isEqualTo(6L);
         assertThat(statusData.get(statusLabels.indexOf("ALLOCATED"))).isEqualTo(4L);
         assertThat(statusData.get(statusLabels.indexOf("EXPIRED"))).isEqualTo(0L);
 
-        List<String> typeLabels = summary.getTypeDistribution().getLabels();
-        List<Long> typeData = summary.getTypeDistribution().getData();
+        List<String> typeLabels = summary.getByType().stream().map(DashboardSummaryDto.TypeCountDto::getType).toList();
+        List<Long> typeData = summary.getByType().stream().map(DashboardSummaryDto.TypeCountDto::getCount).toList();
         assertThat(typeLabels).containsExactly("LAPTOP", "SCREEN", "ACCESSORY");
         assertThat(typeData.get(typeLabels.indexOf("LAPTOP"))).isEqualTo(8L);
         assertThat(typeData.get(typeLabels.indexOf("SCREEN"))).isEqualTo(2L);
@@ -75,7 +76,7 @@ class DashboardServiceTest {
     @Test
     void getQuickSpareLaptop_WhenFound_ReturnsAsset() {
         Asset laptop = new Asset();
-        laptop.setId(1L);
+        laptop.setId(UUID.fromString("00000000-0000-0000-0000-000000000001"));
         laptop.setType(AssetType.LAPTOP);
         laptop.setStatus(AssetStatus.AVAILABLE);
 
@@ -84,7 +85,7 @@ class DashboardServiceTest {
 
         QuickSpareAssetDto result = dashboardService.getQuickSpareLaptop();
         assertThat(result).isNotNull();
-        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getId()).isEqualTo(UUID.fromString("00000000-0000-0000-0000-000000000001"));
         assertThat(result.getType()).isEqualTo("LAPTOP");
         assertThat(result.getStatus()).isEqualTo("AVAILABLE");
     }

--- a/backend/src/test/java/com/assettrack/service/notification/NotificationServiceTest.java
+++ b/backend/src/test/java/com/assettrack/service/notification/NotificationServiceTest.java
@@ -1,5 +1,6 @@
 package com.assettrack.service.notification;
 
+import java.util.UUID;
 import com.assettrack.domain.notification.Notification;
 import com.assettrack.domain.user.Role;
 import com.assettrack.domain.user.User;
@@ -44,7 +45,7 @@ class NotificationServiceTest {
     void getCurrentUserNotifications_ReturnsOnlyAlertsForLoggedInUser() {
         User currentUser = testUser();
         Notification notification = Notification.builder()
-                .id(1L)
+                .id(UUID.fromString("00000000-0000-0000-0000-000000000001"))
                 .recipient(currentUser.getEmail())
                 .messageBody("Laptop warranty expires soon")
                 .type("ALERT")
@@ -69,7 +70,7 @@ class NotificationServiceTest {
     void markAsRead_UpdatesOnlyTheLoggedInUsersNotification() {
         User currentUser = testUser();
         Notification notification = Notification.builder()
-                .id(5L)
+                .id(UUID.fromString("00000000-0000-0000-0000-000000000005"))
                 .recipient(currentUser.getEmail())
                 .messageBody("Condition report created")
                 .type("CONDITION_REPORT")
@@ -91,7 +92,7 @@ class NotificationServiceTest {
 
     private User testUser() {
         return User.builder()
-                .id(7L)
+                .id(UUID.fromString("00000000-0000-0000-0000-000000000007"))
                 .email("developer@assettrack.com")
                 .passwordHash("$2a$12$hashed_password")
                 .role(Role.DEVELOPER)


### PR DESCRIPTION
This PR groups two major logical units of change:
1. Updates the API base path to `/api/v1` across the configuration and testing controllers.
2. Migrates entity IDs from `Long` to `UUID` across the domain, repository, service, and controller layers, along with the required test updates.